### PR TITLE
Adding support for dynamic selection of platform for execution - NativeMehods.cs

### DIFF
--- a/CurlSharp/NativeMethods.cs
+++ b/CurlSharp/NativeMethods.cs
@@ -20,6 +20,8 @@
 //#define USE_LIBCURLSHIM
 
 using System;
+using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace CurlSharp
@@ -29,56 +31,389 @@ namespace CurlSharp
     /// </summary>
     internal static unsafe class NativeMethods
     {
-#if WIN64
-        private const string CURL_LIB = "libcurl64.dll";
-    #if USE_LIBCURLSHIM
-        private const string CURLSHIM_LIB = "libcurlshim64.dll";
-    #endif
-#else
-#if LINUX
-        private const string CURL_LIB = "libcurl";
-#else
-        private const string CURL_LIB = "libcurl.dll";
-#if USE_LIBCURLSHIM
-        private const string CURLSHIM_LIB = "libcurlshim.dll";
-    	#endif
-#endif
-#endif
-#if !USE_LIBCURLSHIM
-#if LINUX
-        private const string WINSOCK_LIB = "libc";
-#else
-        private const string WINSOCK_LIB = "ws2_32.dll";
-#endif
-#endif
+        private const string CURL_LIB_X64 = "libcurl.dll"; // should be in amd64 directory
+        private const string CURL_LIB_X86 = "libcurl.dll"; // should be in i386 directory
+
+        private const string CURL_LIB_LINUX = "libcurl";
+        private const string CURLSHIM_LIB_X64 = "libcurlshim64.dll";
+        private const string CURLSHIM_LIB_X86 = "libcurlshim.dll";
+
+        private const string WINSOCK_LIB_LINUX = "libc";
+        private const string WINSOCK_LIB_X86 = "ws2_32.dll";
+        private const string LIBX64DIR = "amd64";
+        private const string LIBX86DIR = "i386";
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool SetDllDirectory(string lpPathName);
+
+        internal enum NETPlatformType
+        {
+            Unknown,
+            Mono,
+            WinX64,
+            WinX86
+        }
+        private static NETPlatformType platformType = NETPlatformType.Unknown;
+
+        internal static NETPlatformType PlatformType
+        {
+            get
+            {
+                return platformType;
+            }
+
+            set
+            {
+                platformType = value;
+            }
+        }
+        internal static NETPlatformType ProcessPlatformType()
+        {
+            NETPlatformType type;
+            string dllSubFolder = string.Empty;
+            type = GetPlatformType();
+            string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar;
+                 
+            switch (type)
+            {
+                case NETPlatformType.Mono:
+                break;
+                case NETPlatformType.WinX64:
+                dllSubFolder = LIBX64DIR;
+                 
+                break;
+                case NETPlatformType.WinX86:
+                dllSubFolder = LIBX86DIR;
+                 
+                break;
+                case NETPlatformType.Unknown:
+                break;
+                default:
+                    break;
+            }
+        
+            if (type  == NETPlatformType.WinX86 || type == NETPlatformType.WinX64)
+            {
+                path += dllSubFolder;
+                SetDllDirectory(path);
+            }
+         
+            return type;
+
+        }
+        internal static NETPlatformType GetPlatformType()        
+        {
+            NETPlatformType type = NETPlatformType.Unknown;
+            
+            if (Type.GetType("Mono.Runtime") != null)
+            {
+                // Linux: Mono
+                type = NETPlatformType.Mono;
+            }
+            else
+            {
+                
+              
+                // this is Windows NET
+                if (IntPtr.Size == 8)
+                {
+                    // this is x64 process    
+                    type = NETPlatformType.WinX64;
+                
+                }       
+                else if (IntPtr.Size == 4)
+                {
+                   
+                    type = NETPlatformType.WinX86;
+                    
+                }
+
+            }
+
+
+            return type;
+        }
 
         // internal delegates from cURL
-
+        
         // libcurl imports
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_global_init(int flags);
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_global_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_global_init_linux(int flags);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_global_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_global_init_x64(int flags);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_global_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_global_init_x86(int flags);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_global_cleanup();
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        internal static extern IntPtr curl_escape(String url, int length);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        internal static extern IntPtr curl_unescape(String url, int length);
+        internal static CurlCode curl_global_init(int flags)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_free(IntPtr p);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_version();
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_global_init_linux(flags);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_global_init_x86(flags);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_global_init_x64(flags);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+                    
+            }
+            return result;
+        }
+    
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_easy_init();
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_easy_cleanup(IntPtr pCurl);
 
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_global_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_global_cleanup_linux();
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_global_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_global_cleanup_x64();
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_global_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_global_cleanup_x86();
+        
+        internal static void curl_global_cleanup()
+        {
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    curl_global_cleanup_linux();
+                    break;
+                case NETPlatformType.WinX86:
+                    curl_global_cleanup_x86();
+                    break;
+                case NETPlatformType.WinX64:
+                    curl_global_cleanup_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+        }
+    
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_escape", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_escape_linux(String url, int length);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_escape", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_escape_x64(String url, int length);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_escape", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_escape_x86(String url, int length);
+        internal static IntPtr curl_escape(String url, int length)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_escape_linux(url,length);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_escape_x86(url,length);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_escape_x64(url, length);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+    
+
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_unescape", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_unescape_linux(String url, int length);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_unescape", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_unescape_x64(String url, int length);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_unescape", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_unescape_x86(String url, int length);
+
+
+        internal static IntPtr curl_unescape(String url, int length)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_unescape_linux(url, length);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_unescape_x86(url, length);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_unescape_x64(url, length);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_free", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_free_linux(IntPtr p);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_free", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_free_x64(IntPtr p);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_free", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_free_x86(IntPtr p);
+
+        internal static void curl_free(IntPtr p)
+        {
+           
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    curl_free_linux(p);
+                    break;
+                case NETPlatformType.WinX86:
+                    curl_free_x86(p);
+                    break;
+                case NETPlatformType.WinX64:
+                    curl_free_x64(p);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_version", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_version_linux();
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_version", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_version_x64();
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_version", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_version_x86();
+        internal static IntPtr curl_version()
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_version_linux();
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_version_x86();
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_version_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_init_linux();
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_init_x64();
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_init_x86();
+        internal static IntPtr curl_easy_init()
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_init_linux();
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_init_x86();
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_init_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_easy_cleanup_linux(IntPtr pCurl);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_easy_cleanup_x64(IntPtr pCurl);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_easy_cleanup_x86(IntPtr pCurl);
+        internal static void curl_easy_cleanup(IntPtr pCurl)
+        {
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    curl_easy_cleanup(pCurl);
+                    break;
+                case NETPlatformType.WinX86:
+                    curl_easy_cleanup_x86(pCurl);
+                    break;
+                case NETPlatformType.WinX64:
+                    curl_easy_cleanup_x64(pCurl);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+        }
+     
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int _CurlGenericCallback(IntPtr ptr, int sz, int nmemb, IntPtr userdata);
 
@@ -96,51 +431,408 @@ namespace CurlSharp
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate CurlIoError _CurlIoctlCallback(CurlIoCommand cmd, IntPtr parm);
 
+        
         // curl_easy_setopt() overloads
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, IntPtr parm);
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_linux(IntPtr pCurl, CurlOption opt, IntPtr parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x64(IntPtr pCurl, CurlOption opt, IntPtr parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x86(IntPtr pCurl, CurlOption opt, IntPtr parm);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, string parm);
+        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, IntPtr parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, byte[] parm);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, long parm);
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_linux(pCurl,opt,parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, bool parm);
+            }
+            return result;
+        }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, EntryPoint = "curl_easy_setopt")]
-        internal static extern CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, EntryPoint = "curl_easy_setopt")]
-        internal static extern CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm);
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_linux(IntPtr pCurl, CurlOption opt, string parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x64(IntPtr pCurl, CurlOption opt, string parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x86(IntPtr pCurl, CurlOption opt, string parm);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, EntryPoint = "curl_easy_setopt")]
-        internal static extern CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
+        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, string parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, EntryPoint = "curl_easy_setopt")]
-        internal static extern CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, EntryPoint = "curl_easy_setopt")]
-        internal static extern CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
 
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_linux(IntPtr pCurl, CurlOption opt, byte[] parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x64(IntPtr pCurl, CurlOption opt, byte[] parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x86(IntPtr pCurl, CurlOption opt, byte[] parm);
+
+        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, byte[] parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_linux(IntPtr pCurl, CurlOption opt, long parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x64(IntPtr pCurl, CurlOption opt, long parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x86(IntPtr pCurl, CurlOption opt, long parm);
+        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, long parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_linux(IntPtr pCurl, CurlOption opt, bool parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x64(IntPtr pCurl, CurlOption opt, bool parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_x86(IntPtr pCurl, CurlOption opt, bool parm);
+        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, bool parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_linux(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x64(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x86(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm);
+        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_cb_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_cb_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_cb_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_linux(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x64(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x86(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm);
+        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_cb_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_cb_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_cb_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_linux(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x64(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x86(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
+        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_cb_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_cb_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_cb_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_linux(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x64(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x86(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
+        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_cb_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_cb_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_cb_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_linux(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x64(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_setopt_cb_x86(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
+        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_setopt_cb_linux(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_setopt_cb_x86(pCurl, opt, parm);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_setopt_cb_x64(pCurl, opt, parm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+      
 #if !USE_LIBCURLSHIM
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlMultiCode curl_multi_fdset(IntPtr pmulti,
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_fdset_linux(IntPtr pmulti,
                                                               [In, Out] ref fd_set read_fd_set,
                                                               [In, Out] ref fd_set write_fd_set,
                                                               [In, Out] ref fd_set exc_fd_set,
                                                               [In, Out] ref int max_fd);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_fdset_x64(IntPtr pmulti,
+                                                              [In, Out] ref fd_set read_fd_set,
+                                                              [In, Out] ref fd_set write_fd_set,
+                                                              [In, Out] ref fd_set exc_fd_set,
+                                                              [In, Out] ref int max_fd);
+
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_fdset_x86(IntPtr pmulti,
+                                                              [In, Out] ref fd_set read_fd_set,
+                                                              [In, Out] ref fd_set write_fd_set,
+                                                              [In, Out] ref fd_set exc_fd_set,
+                                                              [In, Out] ref int max_fd);
+
+        internal static CurlMultiCode curl_multi_fdset(IntPtr pmulti,
+                                                              [In, Out] ref fd_set read_fd_set,
+                                                              [In, Out] ref fd_set write_fd_set,
+                                                              [In, Out] ref fd_set exc_fd_set,
+                                                              [In, Out] ref int max_fd)
+        {
+            CurlMultiCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_fdset_linux(pmulti, ref read_fd_set, 
+                        ref write_fd_set, ref exc_fd_set,ref  max_fd);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_fdset_x86(pmulti, ref read_fd_set,
+                        ref write_fd_set, ref exc_fd_set, ref  max_fd);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_fdset_x64(pmulti, ref read_fd_set,
+                        ref write_fd_set, ref exc_fd_set, ref  max_fd);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct fd_set
         {
             internal uint fd_count;
             //[MarshalAs(UnmanagedType.ByValArray, SizeConst = FD_SETSIZE)] internal IntPtr[] fd_array;
-            internal fixed uint fd_array [FD_SETSIZE];
+            internal fixed uint fd_array[FD_SETSIZE];
 
             internal const int FD_SETSIZE = 64;
 
@@ -162,7 +854,7 @@ namespace CurlSharp
             {
                 var handle = Create();
                 handle.fd_count = 1;
-                handle.fd_array[0] = (uint) socket;
+                handle.fd_array[0] = (uint)socket;
                 return handle;
             }
         }
@@ -194,180 +886,1664 @@ namespace CurlSharp
             {
                 return new timeval
                        {
-                           tv_sec = milliseconds/1000,
-                           tv_usec = (milliseconds%1000)*1000
+                           tv_sec = milliseconds / 1000,
+                           tv_usec = (milliseconds % 1000) * 1000
                        };
             }
         };
 
-        [DllImport(WINSOCK_LIB, EntryPoint = "select")]
-        internal static extern int select(
+        [DllImport(WINSOCK_LIB_LINUX, EntryPoint = "select")]
+        private static extern int select_linux(
             int nfds, // number of sockets, (ignored in winsock)
             [In, Out] ref fd_set readfds, // read sockets to watch
             [In, Out] ref fd_set writefds, // write sockets to watch
             [In, Out] ref fd_set exceptfds, // error sockets to watch
             ref timeval timeout);
 
+
+
+        [DllImport(WINSOCK_LIB_X86, EntryPoint = "select")]
+        private static extern int select_x86(
+            int nfds, // number of sockets, (ignored in winsock)
+            [In, Out] ref fd_set readfds, // read sockets to watch
+            [In, Out] ref fd_set writefds, // write sockets to watch
+            [In, Out] ref fd_set exceptfds, // error sockets to watch
+            ref timeval timeout);
+
+
+        internal static int select(
+            int nfds, // number of sockets, (ignored in winsock)
+            [In, Out] ref fd_set readfds, // read sockets to watch
+            [In, Out] ref fd_set writefds, // write sockets to watch
+            [In, Out] ref fd_set exceptfds, // error sockets to watch
+            ref timeval timeout)
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = select_linux(
+                                            nfds, // number of sockets, (ignored in winsock)
+                                            ref readfds, // read sockets to watch
+                                            ref writefds, // write sockets to watch
+                                            ref exceptfds, // error sockets to watch
+                                            ref timeout);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = select_x86(
+                                        nfds, // number of sockets, (ignored in winsock)
+                                        ref readfds, // read sockets to watch
+                                        ref writefds, // write sockets to watch
+                                        ref exceptfds, // error sockets to watch
+                                        ref timeout);
+                  break;
+               
+               /* case NETPlatformType.Winx64:
+                    result = curl_multi_fdset_x64(pmulti, ref read_fd_set,
+                        ref write_fd_set, ref exc_fd_set, ref  max_fd);
+                    break;
+                */
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
         //[DllImport(WINSOCK_LIB, EntryPoint = "select")]
-        //internal static extern int select(int ndfs, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timeval* timeout);
+        //internal static int select(int ndfs, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timeval* timeout);
 #endif
+        
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_perform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_perform_linux(IntPtr pCurl);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_perform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_perform_x64(IntPtr pCurl);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_perform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_perform_x86(IntPtr pCurl);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_perform(IntPtr pCurl);
+        internal static CurlCode curl_easy_perform(IntPtr pCurl)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_easy_duphandle(IntPtr pCurl);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_easy_strerror(CurlCode err);
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_perform_linux(pCurl);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_perform_x86(pCurl);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_perform_x64(pCurl);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
+            }
+            return result;
+        }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref double dblVal);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_easy_reset(IntPtr pCurl);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_multi_init();
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_duphandle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_duphandle_linux(IntPtr pCurl);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_duphandle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_duphandle_x64(IntPtr pCurl);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_duphandle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_duphandle_x86(IntPtr pCurl);
+        internal static IntPtr curl_easy_duphandle(IntPtr pCurl)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlMultiCode curl_multi_cleanup(IntPtr pmulti);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlMultiCode curl_multi_add_handle(IntPtr pmulti, IntPtr peasy);
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_duphandle_linux(pCurl);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_duphandle_x86(pCurl);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_duphandle_x64(pCurl);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlMultiCode curl_multi_remove_handle(IntPtr pmulti, IntPtr peasy);
+            }
+            return result;
+        }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_multi_strerror(CurlMultiCode errorNum);
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_strerror_linux(CurlCode err);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_strerror_x64(CurlCode err);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_easy_strerror_x86(CurlCode err);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlMultiCode curl_multi_perform(IntPtr pmulti, ref int runningHandles);
+        internal static IntPtr curl_easy_strerror(CurlCode err)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_formfree(IntPtr pForm);
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_strerror_linux(err);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_strerror_x86(err);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_strerror_x64(err);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_getinfo_linux(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_getinfo_x86(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_getinfo_x64(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
+
+        internal static CurlCode curl_easy_getinfo(IntPtr pCurl,CurlInfo info, ref IntPtr pInfo)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_getinfo_linux(pCurl,info, ref pInfo);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_getinfo_x86(pCurl,info, ref pInfo);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_getinfo_x64(pCurl,info, ref pInfo);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_getinfo_linux(IntPtr pCurl, CurlInfo info, ref double dblVal);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_getinfo_x64(IntPtr pCurl, CurlInfo info, ref double dblVal);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlCode curl_easy_getinfo_x86(IntPtr pCurl, CurlInfo info, ref double dblVal);
+
+        internal static CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref double pInfo)
+        {
+            CurlCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_easy_getinfo_linux(pCurl, info, ref pInfo);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_easy_getinfo_x86(pCurl, info, ref pInfo);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_easy_getinfo_x64(pCurl, info, ref pInfo);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_easy_reset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_easy_reset_linux(IntPtr pCurl);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_easy_reset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_easy_reset_x64(IntPtr pCurl);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_easy_reset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_easy_reset_x86(IntPtr pCurl);
+
+        internal static void curl_easy_reset(IntPtr pCurl)
+        {
+        
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    curl_easy_reset_linux(pCurl);
+                    break;
+                case NETPlatformType.WinX86:
+                    curl_easy_reset_x86(pCurl);
+                    break;
+                case NETPlatformType.WinX64:
+                    curl_easy_reset_x64(pCurl);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+         
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_multi_init_linux();
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_multi_init_x64();
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_multi_init_x86();
+
+        internal static IntPtr curl_multi_init()
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_init_linux();
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_init_x86();
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_init_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_cleanup_linux(IntPtr pmulti);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_cleanup_x86(IntPtr pmulti);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_cleanup_x64(IntPtr pmulti);
+
+
+        internal static CurlMultiCode curl_multi_cleanup(IntPtr pmulti)
+        {
+            CurlMultiCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_cleanup_linux(pmulti);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_cleanup_x86(pmulti);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_cleanup_x64(pmulti);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_add_handle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_add_handle_linux(IntPtr pmulti, IntPtr peasy);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_add_handle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_add_handle_x64(IntPtr pmulti, IntPtr peasy);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_add_handle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_add_handle_x86(IntPtr pmulti, IntPtr peasy);
+        internal static CurlMultiCode curl_multi_add_handle(IntPtr pmulti, IntPtr peasy)
+        {
+            CurlMultiCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_add_handle_linux(pmulti, peasy);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_add_handle_x86(pmulti, peasy);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_add_handle_x64(pmulti, peasy);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_remove_handle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_remove_handle_linux(IntPtr pmulti, IntPtr peasy);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_remove_handle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_remove_handle_x64(IntPtr pmulti, IntPtr peasy);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_remove_handle", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_remove_handle_x86(IntPtr pmulti, IntPtr peasy);
+        internal static CurlMultiCode curl_multi_remove_handle(IntPtr pmulti, IntPtr peasy)
+        {
+            CurlMultiCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_remove_handle_linux(pmulti, peasy);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_remove_handle_x86(pmulti, peasy);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_remove_handle_x64(pmulti, peasy);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_multi_strerror_linux(CurlMultiCode errorNum);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_multi_strerror_x86(CurlMultiCode errorNum);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_multi_strerror_x64(CurlMultiCode errorNum);
+
+        internal static IntPtr curl_multi_strerror(CurlMultiCode errorNum)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_strerror_linux(errorNum);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_strerror_x86(errorNum);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_strerror_x64(errorNum);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_multi_perform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_perform_linux(IntPtr pmulti, ref int runningHandles);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_multi_perform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_perform_x86(IntPtr pmulti, ref int runningHandles);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_multi_perform", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_multi_perform_x64(IntPtr pmulti, ref int runningHandles);
+        internal static CurlMultiCode curl_multi_perform(IntPtr pmulti, ref int runningHandles)
+        {
+            CurlMultiCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_multi_perform_linux(pmulti, ref runningHandles);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_multi_perform_x86(pmulti, ref runningHandles);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_multi_perform_x64(pmulti, ref runningHandles);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_formfree", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_formfree_linux(IntPtr pForm);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_formfree", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_formfree_x86(IntPtr pForm);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_formfree", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_formfree_x64(IntPtr pForm);
+        internal static void curl_formfree(IntPtr pForm)
+        {
+        
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    curl_formfree_linux(pForm);
+                    break;
+                case NETPlatformType.WinX86:
+                    curl_formfree_x86(pForm);
+                    break;
+                case NETPlatformType.WinX64:
+                    curl_formfree_x64(pForm);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+           
+        }
+
+
+     
 
 #if !USE_LIBCURLSHIM
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_formadd(ref IntPtr pHttppost, ref IntPtr pLastPost,
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_formadd", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_formadd_linux(ref IntPtr pHttppost, ref IntPtr pLastPost,
                                                 int codeFirst, IntPtr bufFirst,
                                                 int codeNext, IntPtr bufNext,
                                                 int codeLast);
+
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_formadd", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_formadd_x64(ref IntPtr pHttppost, ref IntPtr pLastPost,
+                                                int codeFirst, IntPtr bufFirst,
+                                                int codeNext, IntPtr bufNext,
+                                                int codeLast);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_formadd", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_formadd_x86(ref IntPtr pHttppost, ref IntPtr pLastPost,
+                                                int codeFirst, IntPtr bufFirst,
+                                                int codeNext, IntPtr bufNext,
+                                                int codeLast);
+        internal static int curl_formadd(ref IntPtr pHttppost, ref IntPtr pLastPost,
+                                                int codeFirst, IntPtr bufFirst,
+                                                int codeNext, IntPtr bufNext,
+                                                int codeLast)
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_formadd_linux(ref  pHttppost, ref  pLastPost,
+                                                codeFirst,  bufFirst,
+                                                 codeNext,  bufNext,
+                                                codeLast);
+                    break;
+                case NETPlatformType.WinX86:
+                    result = curl_formadd_x86(ref  pHttppost, ref  pLastPost,
+                                                codeFirst,  bufFirst,
+                                                 codeNext,  bufNext,
+                                                codeLast);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_formadd_x64(ref  pHttppost, ref  pLastPost,
+                                   codeFirst, bufFirst,
+                                    codeNext, bufNext,
+                                   codeLast);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
 #endif
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_share_init();
+        
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_share_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_share_init_linux();
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_share_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_share_init_x64();
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_share_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_share_init_x86();
+        internal static IntPtr curl_share_init()
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlShareCode curl_share_cleanup(IntPtr pShare);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_share_strerror(CurlShareCode errorCode);
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_share_init_linux();
+                    break;
+                case NETPlatformType.WinX86:
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlShareCode curl_share_setopt(IntPtr pShare, CurlShareOption optCode, IntPtr option);
+                    result = curl_share_init_x86();              
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_share_init_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        internal static extern IntPtr curl_slist_append(IntPtr slist, string data);
+            }
+            return result;
+        }
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlShareCode curl_slist_free_all(IntPtr pList);
 
-        [DllImport(CURL_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_version_info(CurlVersion ver);
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_share_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_share_cleanup_linux(IntPtr pShare);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_share_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_share_cleanup_x64(IntPtr pShare);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_share_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_share_cleanup_x86(IntPtr pShare);
+        internal static CurlShareCode curl_share_cleanup(IntPtr pShare)
+        {
+            CurlShareCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-#if USE_LIBCURLSHIM
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_share_cleanup_linux(pShare);
+                    break;
+                case NETPlatformType.WinX86:
+
+                    result = curl_share_cleanup_x86(pShare);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_share_cleanup_x64(pShare);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_share_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_share_strerror_linux(CurlShareCode errorCode);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_share_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_share_strerror_x86(CurlShareCode errorCode);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_share_strerror", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_share_strerror_x64(CurlShareCode errorCode);
+
+        internal static IntPtr curl_share_strerror(CurlShareCode errorCode)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_share_strerror_linux(errorCode);
+                    break;
+                case NETPlatformType.WinX86:
+
+                    result = curl_share_strerror_x86(errorCode);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_share_strerror(errorCode);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_share_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_share_setopt_linux(IntPtr pShare, CurlShareOption optCode, IntPtr option);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_share_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_share_setopt_x64(IntPtr pShare, CurlShareOption optCode, IntPtr option);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_share_setopt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_share_setopt_x86(IntPtr pShare, CurlShareOption optCode, IntPtr option);
+        internal static CurlShareCode curl_share_setopt(IntPtr pShare,CurlShareOption optCode, IntPtr option)
+        {
+            CurlShareCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_share_setopt_linux(pShare, optCode, option);
+                    break;
+                case NETPlatformType.WinX86:
+
+                    result = curl_share_setopt_x86(pShare, optCode, option);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_share_setopt_x64(pShare, optCode, option);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_slist_append", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_slist_append_linux(IntPtr slist, string data);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_slist_append", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_slist_append_x64(IntPtr slist, string data);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_slist_append", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_slist_append_x86(IntPtr slist, string data);
+
+        internal static IntPtr curl_slist_append(IntPtr slist, string data)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_slist_append_linux(slist,data);
+                    break;
+                case NETPlatformType.WinX86:
+
+                    result = curl_slist_append_x86(slist, data);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_slist_append_x64(slist, data);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_slist_free_all_linux(IntPtr pList);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_slist_free_all_x86(IntPtr pList);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlShareCode curl_slist_free_all_x64(IntPtr pList);
+        internal static CurlShareCode curl_slist_free_all(IntPtr pList)
+        {
+            CurlShareCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result =  curl_slist_free_all_linux(pList);
+                    break;
+                case NETPlatformType.WinX86:
+
+                    result = curl_slist_free_all_x86(pList);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_slist_free_all_x64(pList);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURL_LIB_LINUX, EntryPoint = "curl_version_info", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_version_info_linux(CurlVersion ver);
+        [DllImport(CURL_LIB_X64, EntryPoint = "curl_version_info", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_version_info_x86(CurlVersion ver);
+        [DllImport(CURL_LIB_X86, EntryPoint = "curl_version_info", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_version_info_x64(CurlVersion ver);
+        
+        internal static IntPtr curl_version_info(CurlVersion ver)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Mono:
+                    result = curl_version_info_linux(ver);
+                    break;
+                case NETPlatformType.WinX86:
+
+                    result = curl_version_info_x86(ver);
+                    break;
+                case NETPlatformType.WinX64:
+                    result = curl_version_info_x64(ver);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not determine type of NET platform");
+
+            }
+            return result;
+        }
+
+
+
+     
+#if  USE_LIBCURLSHIM
 
     // libcurlshim imports
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_initialize();
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_initialize", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_initialize_x64();
+        [DllImport(CURLSHIM_LIB_X86,EntryPoint = "curl_shim_initialize", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_initialize_x86();
+        internal static void curl_shim_initialize()
+        {
+           
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_cleanup();
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_shim_alloc_strings();
+            switch (PlatformType)
+            {
+                case NETPlatformType.Winx86:
+                    curl_shim_initialize_x86();
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_initialize_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl,
+            }
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64,EntryPoint = "curl_shim_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_cleanup_x64();
+        [DllImport(CURLSHIM_LIB_X86,EntryPoint = "curl_shim_cleanup", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_cleanup_x86();
+        internal static void curl_shim_cleanup()
+        {
+
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Winx86:
+                    curl_shim_cleanup_x86();
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_cleanup_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+    
+
+        [DllImport(CURLSHIM_LIB_X64,EntryPoint = "curl_shim_alloc_strings", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_alloc_strings_x64();
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_alloc_strings", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_alloc_strings_x86();
+
+        internal static void curl_shim_alloc_strings()
+        {
+
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+                case NETPlatformType.Winx86:
+                    curl_shim_alloc_strings_x86();
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_alloc_strings_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_add_string_to_slist", CallingConvention = CallingConvention.Cdecl,
             CharSet = CharSet.Ansi)]
-        internal static extern IntPtr curl_shim_add_string_to_slist(
+        private static extern IntPtr curl_shim_add_string_to_slist_x64(
+            IntPtr pStrings, String str);
+        [DllImport(CURLSHIM_LIB_X86, CallingConvention = CallingConvention.Cdecl,
+          CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_shim_add_string_to_slist_x86(
             IntPtr pStrings, String str);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl,
+        internal static IntPtr curl_shim_add_string_to_slist(
+            IntPtr pStrings, String str)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+               
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_add_string_to_slist_x86(pStrings, str);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_add_string_to_slist_x64(pStrings, str);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_get_string_from_slist", CallingConvention = CallingConvention.Cdecl,
             CharSet = CharSet.Ansi)]
-        internal static extern IntPtr curl_shim_get_string_from_slist(
+        private static extern IntPtr curl_shim_get_string_from_slist_x64(
+            IntPtr pSlist, ref IntPtr pStr);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_get_string_from_slist", CallingConvention = CallingConvention.Cdecl,
+            CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_shim_get_string_from_slist_x86(
             IntPtr pSlist, ref IntPtr pStr);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl,
+        internal static IntPtr curl_shim_get_string_from_slist(
+              IntPtr pSlist, ref IntPtr pStr)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_get_string_from_slist_x86(pSlist, ref pStr);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_get_string_from_slist_x64(pSlist, ref pStr);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_add_string", CallingConvention = CallingConvention.Cdecl,
             CharSet = CharSet.Ansi)]
-        internal static extern IntPtr curl_shim_add_string(IntPtr pStrings, String str);
+        private static extern IntPtr curl_shim_add_string_x64(IntPtr pStrings, String str);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_free_strings(IntPtr pStrings);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_add_string", CallingConvention = CallingConvention.Cdecl,
+          CharSet = CharSet.Ansi)]
+        private static extern IntPtr curl_shim_add_string_x86(IntPtr pStrings, String str);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_shim_install_delegates(IntPtr pCurl, IntPtr pThis,
+
+        internal static IntPtr  curl_shim_add_string(IntPtr pStrings, String str)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_add_string_x86(pStrings,str);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_add_string_x64(pStrings, str);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_free_strings", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_free_strings_x64(IntPtr pStrings);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_free_strings", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_free_strings_x86(IntPtr pStrings);
+
+        internal static void curl_shim_free_strings(IntPtr pStrings)
+        {
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    curl_shim_free_strings_x86(pStrings);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_free_strings_x64(pStrings);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+     
+        }
+
+
+
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_install_delegates", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_install_delegates_x64(IntPtr pCurl, IntPtr pThis,
+            _ShimWriteCallback pWrite, _ShimReadCallback pRead,
+            _ShimProgressCallback pProgress, _ShimDebugCallback pDebug,
+            _ShimHeaderCallback pHeader, _ShimSslCtxCallback pCtx,
+            _ShimIoctlCallback pIoctl);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_install_delegates", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_install_delegates_x86(IntPtr pCurl, IntPtr pThis,
             _ShimWriteCallback pWrite, _ShimReadCallback pRead,
             _ShimProgressCallback pProgress, _ShimDebugCallback pDebug,
             _ShimHeaderCallback pHeader, _ShimSslCtxCallback pCtx,
             _ShimIoctlCallback pIoctl);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_cleanup_delegates(IntPtr pThis);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_get_file_time(int unixTime,
+
+        internal static int  curl_shim_install_delegates(IntPtr pCurl, IntPtr pThis,
+            _ShimWriteCallback pWrite, _ShimReadCallback pRead,
+            _ShimProgressCallback pProgress, _ShimDebugCallback pDebug,
+            _ShimHeaderCallback pHeader, _ShimSslCtxCallback pCtx,
+            _ShimIoctlCallback pIoctl)
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_install_delegates_x86(pCurl, pThis,
+             pWrite,pRead,
+             pProgress, pDebug,
+             pHeader, pCtx,
+            pIoctl);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_install_delegates_x64(pCurl, pThis,
+             pWrite, pRead,
+             pProgress, pDebug,
+             pHeader, pCtx,
+            pIoctl);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURLSHIM_LIB_X64,EntryPoint = "curl_shim_cleanup_delegates", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_cleanup_delegates_x64(IntPtr pThis);
+        [DllImport(CURLSHIM_LIB_X86,EntryPoint = "curl_shim_cleanup_delegates", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_cleanup_delegates_x86(IntPtr pThis);
+
+        internal static void curl_shim_cleanup_delegates(IntPtr pThis)
+        {
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                curl_shim_cleanup_delegates_x86(pThis);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_cleanup_delegates_x64(pThis);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_get_file_time", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_get_file_time_x64(int unixTime,
+            ref int yy, ref int mm, ref int dd, ref int hh, ref int mn, ref int ss);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_get_file_time", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_get_file_time_x86(int unixTime,
             ref int yy, ref int mm, ref int dd, ref int hh, ref int mn, ref int ss);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_free_slist(IntPtr p);
+        internal static void curl_shim_get_file_time(int unixTime,
+            ref int yy, ref int mm, ref int dd, ref int hh, ref int mn, ref int ss)
+        {
+         
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_shim_alloc_fd_sets();
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_free_fd_sets(IntPtr fdsets);
+            switch (PlatformType)
+            {
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern CurlMultiCode curl_shim_multi_fdset(IntPtr multi,
+                case NETPlatformType.Winx86:
+
+                     curl_shim_get_file_time_x86(unixTime,
+            ref  yy, ref mm, ref dd, ref hh, ref mn, ref ss);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_get_file_time_x64(unixTime,
+               ref  yy, ref mm, ref dd, ref hh, ref mn, ref ss);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_get_file_time", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_free_slist_x64(IntPtr p);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_get_file_time",CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_free_slist_x86(IntPtr p);
+        internal static void curl_shim_free_slist(IntPtr p)
+        {
+
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    curl_shim_free_slist_x86(p);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_free_slist_x64(p);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_alloc_fd_sets", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_alloc_fd_sets_x64();
+        [DllImport(CURLSHIM_LIB_X86,  EntryPoint = "curl_shim_alloc_fd_sets",CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_alloc_fd_sets_x86();
+
+        internal static IntPtr curl_shim_alloc_fd_sets()
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_alloc_fd_sets_x86();
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_alloc_fd_sets_x64();
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_free_fd_sets", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_free_fd_sets_x64(IntPtr fdsets);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_free_fd_sets", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_free_fd_sets_x86(IntPtr fdsets);
+        internal static void  curl_shim_free_fd_sets(IntPtr fdsets)
+        {
+
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    curl_shim_free_fd_sets_x86(fdsets);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_free_fd_sets_x64(fdsets);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_shim_multi_fdset_x64(IntPtr multi,
+            IntPtr fdsets, ref int maxFD);
+        [DllImport(CURLSHIM_LIB_X86,  EntryPoint = "curl_shim_multi_fdset",CallingConvention = CallingConvention.Cdecl)]
+        private static extern CurlMultiCode curl_shim_multi_fdset_x86(IntPtr multi,
             IntPtr fdsets, ref int maxFD);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_shim_select(int maxFD, IntPtr fdsets,
+
+
+        internal static CurlMultiCode curl_shim_multi_fdset(IntPtr multi,
+            IntPtr fdsets, ref int maxFD)
+        {
+            CurlMultiCode result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_multi_fdset_x86(multi,
+                        fdsets, ref  maxFD);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_multi_fdset_x64(multi,
+                        fdsets, ref  maxFD);
+          
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_select", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_select_x64(int maxFD, IntPtr fdsets,
+            int milliseconds);
+        [DllImport(CURLSHIM_LIB_X86,EntryPoint = "curl_shim_select", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_select_x86(int maxFD, IntPtr fdsets,
             int milliseconds);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_shim_multi_info_read(IntPtr multi,
+        internal static int curl_shim_select(int maxFD, IntPtr fdsets,
+            int milliseconds)
+
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_select_x86(maxFD, fdsets,
+            milliseconds);
+                    break;
+                case NETPlatformType.Winx64:
+                     result = curl_shim_select_x64(maxFD, fdsets,
+                milliseconds);
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_multi_info_read", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_multi_info_read_x64(IntPtr multi,
+            ref int nMsgs);
+        [DllImport(CURLSHIM_LIB_X86,EntryPoint = "curl_shim_multi_info_read", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_multi_info_read_x86(IntPtr multi,
             ref int nMsgs);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_multi_info_free(IntPtr multiInfo);
+        internal static IntPtr curl_shim_multi_info_read(IntPtr multi,
+            ref int nMsgs)
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_shim_formadd(IntPtr[] ppForms, IntPtr[] pParams, int nParams);
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_shim_install_share_delegates(IntPtr pShare,
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_multi_info_read_x86(multi, ref nMsgs);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_multi_info_read_x64(multi, ref nMsgs);
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_multi_info_free", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_multi_info_free_x64(IntPtr multiInfo);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_multi_info_free", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_multi_info_free_x86(IntPtr multiInfo);
+
+        internal static void curl_shim_multi_info_free(IntPtr multiInfo)
+        {
+
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    curl_shim_multi_info_free_x86(multiInfo);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_multi_info_free_x64(multiInfo);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_formadd", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_formadd_x64(IntPtr[] ppForms, IntPtr[] pParams, int nParams);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_formadd", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_formadd_x86(IntPtr[] ppForms, IntPtr[] pParams, int nParams);
+
+        internal static int curl_shim_formadd(IntPtr[] ppForms, IntPtr[] pParams, int nParams) 
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_formadd_x86( ppForms, pParams,nParams); 
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_formadd_x64(ppForms, pParams, nParams); 
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_install_share_delegates", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_install_share_delegates_x64(IntPtr pShare,
+            IntPtr pThis, _ShimLockCallback pLock, _ShimUnlockCallback pUnlock);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_install_share_delegates",CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_install_share_delegates_x86(IntPtr pShare,
             IntPtr pThis, _ShimLockCallback pLock, _ShimUnlockCallback pUnlock);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void curl_shim_cleanup_share_delegates(IntPtr pShare);
+        internal static int curl_shim_install_share_delegates(IntPtr pShare,
+            IntPtr pThis, _ShimLockCallback pLock, _ShimUnlockCallback pUnlock)
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_shim_get_version_int_value(IntPtr p, int offset);
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_shim_get_version_char_ptr(IntPtr p, int offset);
+            switch (PlatformType)
+            {
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int curl_shim_get_number_of_protocols(IntPtr p, int offset);
+                case NETPlatformType.Winx86:
 
-        [DllImport(CURLSHIM_LIB, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr curl_shim_get_protocol_string(IntPtr p, int offset, int index);
+                    result = curl_shim_install_share_delegates_x86(pShare,
+             pThis,pLock, pUnlock);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_install_share_delegates_x64(pShare,
+              pThis, pLock, pUnlock);
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "url_shim_cleanup_share_delegates", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_cleanup_share_delegates_x64(IntPtr pShare);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "url_shim_cleanup_share_delegates",CallingConvention = CallingConvention.Cdecl)]
+        private static extern void curl_shim_cleanup_share_delegates_x86(IntPtr pShare);
+
+        internal static void curl_shim_cleanup_share_delegates(IntPtr pShare)
+        {
+
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    curl_shim_cleanup_share_delegates_x86(pShare);
+                    break;
+                case NETPlatformType.Winx64:
+                    curl_shim_cleanup_share_delegates_x86(pShare);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+        }
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_get_version_int_value", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_get_version_int_value_x64(IntPtr p, int offset);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_get_version_int_value", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_get_version_int_value_x86(IntPtr p, int offset);
+
+        internal static int curl_shim_get_version_int_value(IntPtr p, int offset)
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_get_version_int_value_x86(p, offset);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_get_version_int_value_x64(p, offset);
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_get_version_char_ptr", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_get_version_char_ptr_x64(IntPtr p, int offset);
+        [DllImport(CURLSHIM_LIB_X86,  EntryPoint = "curl_shim_get_version_char_ptr",CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_get_version_char_ptr_x86(IntPtr p, int offset);
+
+        internal static IntPtr curl_shim_get_version_char_ptr(IntPtr p, int offset)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_get_version_char_ptr_x86(p, offset);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_get_version_char_ptr_x64(p, offset);
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+        [DllImport(CURLSHIM_LIB_X64,EntryPoint = "curl_shim_get_number_of_protocols", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_get_number_of_protocols_x64(IntPtr p, int offset);
+        [DllImport(CURLSHIM_LIB_X86, EntryPoint = "curl_shim_get_number_of_protocols",CallingConvention = CallingConvention.Cdecl)]
+        private static extern int curl_shim_get_number_of_protocols_x86(IntPtr p, int offset);
+        internal static int curl_shim_get_number_of_protocols(IntPtr p, int offset)
+        {
+            int result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_get_number_of_protocols_x86(p, offset);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_get_number_of_protocols_x64(p, offset);
+
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
+
+
+
+        [DllImport(CURLSHIM_LIB_X64, EntryPoint = "curl_shim_get_protocol_string", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_get_protocol_string_x64(IntPtr p, int offset, int index);
+        [DllImport(CURLSHIM_LIB_X86,  EntryPoint = "curl_shim_get_protocol_string" ,CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr curl_shim_get_protocol_string_x86(IntPtr p, int offset, int index);
+
+
+        internal static IntPtr curl_shim_get_protocol_string(IntPtr p, int offset, int index)
+        {
+            IntPtr result;
+            if (PlatformType == NETPlatformType.Unknown)
+            {
+                PlatformType = ProcessPlatformType();
+            }
+
+
+            switch (PlatformType)
+            {
+
+                case NETPlatformType.Winx86:
+
+                    result = curl_shim_get_protocol_string_x86(p, offset, index);
+                    break;
+                case NETPlatformType.Winx64:
+                    result = curl_shim_get_protocol_string_x64(p, offset, index);
+                    break;
+                default:
+                    throw new InvalidOperationException("Can not run on other platform than Win NET");
+
+            }
+            return result;
+        }
 
         internal delegate void _ShimLockCallback(int data, int access, IntPtr userPtr);
 

--- a/Samples/BookPost/BookPost.csproj
+++ b/Samples/BookPost/BookPost.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/BookPost/BookPost.csproj
+++ b/Samples/BookPost/BookPost.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/EasyGet/EasyGet.csproj
+++ b/Samples/EasyGet/EasyGet.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /c /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/EasyGet/EasyGet.csproj
+++ b/Samples/EasyGet/EasyGet.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /c /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/EasyPost/EasyPost.cs
+++ b/Samples/EasyPost/EasyPost.cs
@@ -10,7 +10,7 @@ namespace EasyPost
     {
         // Upload the provided PHP script (testpost.php) to webroot and modify the 
         // following URL accordingly
-        private const string TEST_URL = "http://localhost/testpost.php";
+        private const string TEST_URL = "http://www.wp.pl";
 
         private static void Main(string[] args)
         {

--- a/Samples/EasyPost/EasyPost.cs
+++ b/Samples/EasyPost/EasyPost.cs
@@ -10,7 +10,7 @@ namespace EasyPost
     {
         // Upload the provided PHP script (testpost.php) to webroot and modify the 
         // following URL accordingly
-        private const string TEST_URL = "http://www.wp.pl";
+        private const string TEST_URL = "http://localhost/testpost.php";
 
         private static void Main(string[] args)
         {

--- a/Samples/EasyPost/EasyPost.csproj
+++ b/Samples/EasyPost/EasyPost.csproj
@@ -14,7 +14,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -49,6 +49,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/EasyPost/EasyPost.csproj
+++ b/Samples/EasyPost/EasyPost.csproj
@@ -14,7 +14,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -49,9 +49,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/FileUpload/FileUpload.csproj
+++ b/Samples/FileUpload/FileUpload.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/FileUpload/FileUpload.csproj
+++ b/Samples/FileUpload/FileUpload.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/Headers/Headers.csproj
+++ b/Samples/Headers/Headers.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/Headers/Headers.csproj
+++ b/Samples/Headers/Headers.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/InfoDemo/InfoDemo.csproj
+++ b/Samples/InfoDemo/InfoDemo.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/InfoDemo/InfoDemo.csproj
+++ b/Samples/InfoDemo/InfoDemo.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/MultiDemo/MultiDemo.csproj
+++ b/Samples/MultiDemo/MultiDemo.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/MultiDemo/MultiDemo.csproj
+++ b/Samples/MultiDemo/MultiDemo.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/SSLGet/SSLGet.csproj
+++ b/Samples/SSLGet/SSLGet.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/SSLGet/SSLGet.csproj
+++ b/Samples/SSLGet/SSLGet.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/ShareDemo/ShareDemo.csproj
+++ b/Samples/ShareDemo/ShareDemo.csproj
@@ -52,4 +52,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/ShareDemo/ShareDemo.csproj
+++ b/Samples/ShareDemo/ShareDemo.csproj
@@ -52,7 +52,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/SmtpMail/SmtpMail.csproj
+++ b/Samples/SmtpMail/SmtpMail.csproj
@@ -49,9 +49,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/SmtpMail/SmtpMail.csproj
+++ b/Samples/SmtpMail/SmtpMail.csproj
@@ -49,6 +49,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/Upload/Upload.csproj
+++ b/Samples/Upload/Upload.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/Upload/Upload.csproj
+++ b/Samples/Upload/Upload.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/VersionData/VersionData.csproj
+++ b/Samples/VersionData/VersionData.csproj
@@ -51,7 +51,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/VersionData/VersionData.csproj
+++ b/Samples/VersionData/VersionData.csproj
@@ -51,4 +51,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Samples/WinSamples/WinSamples.csproj
+++ b/Samples/WinSamples/WinSamples.csproj
@@ -93,7 +93,4 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Samples/WinSamples/WinSamples.csproj
+++ b/Samples/WinSamples/WinSamples.csproj
@@ -93,4 +93,7 @@
       <Name>CurlSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y /e $(SolutionDir)\libs\*.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hello,

I'd like to give you my changes under consideration - they enable dynamic selection of platform for execution for CurlSharp. The idea is that we provide wrappers for x86/x64/Linux and execute them depending on host execution environment type (x86/x64/Mono). 
There are also sample changes for solution files.  
