### PR TITLE
Have CurlMulti.InfoRead() fail when unimplemented.

### DIFF
--- a/CurlSharp/CurlMulti.cs
+++ b/CurlSharp/CurlMulti.cs
@@ -253,7 +253,8 @@ namespace CurlSharp
         }
 
         /// <summary>
-        ///     Obtain status information for a CurlMulti transfer.
+        ///     Obtain status information for a CurlMulti transfer. Requires
+        ///     CurlSharp be compiled with the libcurlshim helper.
         /// </summary>
         /// <returns>
         ///     An array of <see cref="CurlMultiInfo" /> objects, one for each
@@ -285,8 +286,17 @@ namespace CurlSharp
                 }
                 NativeMethods.curl_shim_multi_info_free(pInfo);
             }
-#endif
+
             return _multiInfo;
+
+#else
+
+            throw new NotImplementedException(
+                "Sorry, CurlMulti.InfoRead is not implemented on this system."
+            );
+
+#endif
+
         }
     }
 }


### PR DESCRIPTION
This simply throws an exception if we can't complete the user's request, making it very obvious that what they've tried is not going to work.

Apologies this is a little late; it's been a busy busy week!

Closes #9.