### PR TITLE
Fix issue with USE_LIBCURLSHIM compile-time flag

### DIFF
--- a/CurlSharp/CurlEasy.cs
+++ b/CurlSharp/CurlEasy.cs
@@ -1648,7 +1648,9 @@ namespace CurlSharp
             ensureHandle();
 
             CurlCode nativeRet = NativeMethods.curl_easy_perform(_pCurl);
+#if !USE_LIBCURLSHIM
             freeHandle(ref _curlWriteData);
+#endif
 
             return nativeRet;
         }

--- a/CurlSharp/CurlSharp.csproj
+++ b/CurlSharp/CurlSharp.csproj
@@ -12,13 +12,15 @@
     <FileAlignment>512</FileAlignment>
     <ProductVersion>12.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;LINUX</DefineConstants>
+    <DefineConstants>DEBUG;WIN64,USE_LIBCURLSHIM</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -30,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>WIN64,USE_LIBCURLSHIM</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -84,8 +87,11 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup />
   <ItemGroup>
-    <Folder Include="Enums\" />
-    <Folder Include="Callbacks\" />
+    <ProjectReference Include="..\libcurlshim\libcurlshim64.vcxproj">
+      <Project>{1ecb7656-ae8b-4351-af10-746eb326b24f}</Project>
+      <Name>libcurlshim64</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
You will need to merge the tiny fix from CurlEasy.cs for the shim to work.

The other changes can be ignored as I was just changing things over to a WIN64 build & referenced the libcurlshim64 project. Sorry I should have committed these separately.