### PR TITLE
Native methods cleanup

### DIFF
--- a/CurlSharp/Curl.cs
+++ b/CurlSharp/Curl.cs
@@ -100,48 +100,6 @@ namespace CurlSharp
         }
 
         /// <summary>
-        ///     URL encode a String.
-        /// </summary>
-        /// <param name="url">The string to URL encode.</param>
-        /// <param name="length">
-        ///     Input string length;
-        ///     use 0 for cURL to determine.
-        /// </param>
-        /// <returns>A new URL encoded string.</returns>
-        /// <exception cref="System.InvalidOperationException">
-        ///     Thrown if cURL isn't properly initialized.
-        /// </exception>
-        public static string Escape(string url, int length)
-        {
-            EnsureCurl();
-            var p = NativeMethods.curl_escape(url, length);
-            var s = Marshal.PtrToStringAnsi(p);
-            NativeMethods.curl_free(p);
-            return s;
-        }
-
-        /// <summary>
-        ///     URL decode a String.
-        /// </summary>
-        /// <param name="url">The string to URL decode.</param>
-        /// <param name="length">
-        ///     Input string length;
-        ///     use 0 for cURL to determine.
-        /// </param>
-        /// <returns>A new URL decoded string.</returns>
-        /// <exception cref="System.InvalidOperationException">
-        ///     Thrown if cURL isn't properly initialized.
-        /// </exception>
-        public static string Unescape(string url, int length)
-        {
-            EnsureCurl();
-            var p = NativeMethods.curl_unescape(url, length);
-            var s = Marshal.PtrToStringAnsi(p);
-            NativeMethods.curl_free(p);
-            return s;
-        }
-
-        /// <summary>
         ///     Get a <see cref="CurlVersionInfoData" /> object.
         /// </summary>
         /// <param name="ver">

--- a/CurlSharp/CurlEasy.cs
+++ b/CurlSharp/CurlEasy.cs
@@ -1661,6 +1661,54 @@ namespace CurlSharp
         }
 
         /// <summary>
+        ///     URL encode a String.
+        /// </summary>
+        /// <param name="url">The string to URL encode.</param>
+        /// <param name="length">
+        ///     Input string length;
+        ///     use 0 for cURL to determine.
+        /// </param>
+        /// <returns>A new URL encoded string.</returns>
+        /// <exception cref="NullReferenceException">
+        ///     This is thrown if
+        ///     the native <c>CURL*</c> handle wasn't created successfully.
+        /// </exception>
+        public string Escape(string url)
+        {
+            ensureHandle();
+
+            var length = System.Text.Encoding.ASCII.GetBytes(url).Length;
+            var p = NativeMethods.curl_easy_escape(_pCurl, url, length);
+            var s = Marshal.PtrToStringAnsi(p);
+            NativeMethods.curl_free(p);
+            return s;
+        }
+
+        /// <summary>
+        ///     URL decode a String.
+        /// </summary>
+        /// <param name="url">The string to URL decode.</param>
+        /// <param name="length">
+        ///     Input string length;
+        ///     use 0 for cURL to determine.
+        /// </param>
+        /// <returns>A new URL decoded string.</returns>
+        /// <exception cref="NullReferenceException">
+        ///     This is thrown if
+        ///     the native <c>CURL*</c> handle wasn't created successfully.
+        /// </exception>
+        public string Unescape(string url)
+        {
+            ensureHandle();
+            
+            var length = System.Text.Encoding.ASCII.GetBytes(url).Length;
+            var p = NativeMethods.curl_easy_unescape(_pCurl, url, length, out int outLength);
+            var s = Marshal.PtrToStringAnsi(p, outLength);
+            NativeMethods.curl_free(p);
+            return s;
+        }
+
+        /// <summary>
         ///     Get a string description of an error code.
         /// </summary>
         /// <param name="code">Error code.</param>

--- a/CurlSharp/CurlEasy.cs
+++ b/CurlSharp/CurlEasy.cs
@@ -1963,19 +1963,19 @@ namespace CurlSharp
             _pcbSslCtx = _curlSslCtxCallback;
             _pcbIoctl = _curlIoctlCallback;
 
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.WriteFunction, _pcbWrite),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.WriteFunction, _pcbWrite),
                 CurlOption.WriteFunction);
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.ReadFunction, _pcbRead),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.ReadFunction, _pcbRead),
                 CurlOption.ReadFunction);
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.ProgressFunction, _pcbProgress),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.ProgressFunction, _pcbProgress),
                 CurlOption.ProgressFunction);
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.HeaderFunction, _pcbHeader),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.HeaderFunction, _pcbHeader),
                 CurlOption.HeaderFunction);
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.DebugFunction, _pcbDebug),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.DebugFunction, _pcbDebug),
                 CurlOption.DebugFunction);
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.SslCtxFunction, _pcbSslCtx),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.SslCtxFunction, _pcbSslCtx),
                 CurlOption.SslCtxFunction);
-            setLastError(NativeMethods.curl_easy_setopt_cb(_pCurl, CurlOption.IoctlFunction, _pcbIoctl),
+            setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.IoctlFunction, _pcbIoctl),
                 CurlOption.IoctlFunction);
             setLastError(NativeMethods.curl_easy_setopt(_pCurl, CurlOption.NoProgress, (IntPtr) 0),
                 CurlOption.NoProgress);

--- a/CurlSharp/NativeMethods.cs
+++ b/CurlSharp/NativeMethods.cs
@@ -72,7 +72,7 @@ namespace CurlSharp
         {
             get
             {
-                var codeBase = Assembly.GetEntryAssembly().CodeBase;
+                var codeBase = typeof(NativeMethods).GetTypeInfo().Assembly.CodeBase;
                 var uri = new UriBuilder(codeBase);
                 var path = Uri.UnescapeDataString(uri.Path);
                 return Path.GetDirectoryName(path);

--- a/CurlSharp/NativeMethods.cs
+++ b/CurlSharp/NativeMethods.cs
@@ -46,6 +46,15 @@ namespace CurlSharp
 
         private const string LIB_DIR_WIN32 = "i386";
 
+        static NativeMethods()
+        {
+            PlatformType = ProcessPlatformType();
+#if USE_LIBCURLSHIM
+            if (PlatformType == NETPlatformType.Unknown || PlatformType == NETPlatformType.Unix)
+                throw new InvalidOperationException("Can not run on other platform than Win NET");
+#endif
+        }
+
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool SetDllDirectory(string lpPathName);
 
@@ -68,7 +77,7 @@ namespace CurlSharp
             }
         }
 
-        internal static NETPlatformType PlatformType { get; set; } = NETPlatformType.Unknown;
+        internal static NETPlatformType PlatformType { get; }
 
         internal static NETPlatformType ProcessPlatformType()
         {
@@ -128,15 +137,8 @@ namespace CurlSharp
         [DllImport(CURL_LIB_WIN, EntryPoint = "curl_global_init", CallingConvention = CallingConvention.Cdecl)]
         private static extern CurlCode curl_global_init_win(int flags);
 
-        private static void InitPlatformType()
-        {
-            if (PlatformType == NETPlatformType.Unknown) PlatformType = ProcessPlatformType();
-        }
-
         internal static CurlCode curl_global_init(int flags)
         {
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -154,8 +156,6 @@ namespace CurlSharp
 
         internal static void curl_global_cleanup()
         {
-            InitPlatformType();
-
             if (PlatformType == NETPlatformType.Unix)
                 curl_global_cleanup_unix();
             else
@@ -172,7 +172,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_escape(string url, int length)
         {
-            InitPlatformType();
             return PlatformType == NETPlatformType.Unix ? curl_escape_unix(url, length) : curl_escape_win(url, length);
         }
 
@@ -187,7 +186,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_unescape(string url, int length)
         {
-            InitPlatformType();
             return PlatformType == NETPlatformType.Unix
                 ? curl_unescape_unix(url, length)
                 : curl_unescape_win(url, length);
@@ -201,8 +199,6 @@ namespace CurlSharp
 
         internal static void curl_free(IntPtr p)
         {
-            InitPlatformType();
-
             if (PlatformType == NETPlatformType.Unix)
                 curl_free_unix(p);
             else
@@ -218,7 +214,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_version()
         {
-            InitPlatformType();
             return PlatformType == NETPlatformType.Unix ? curl_version_unix() : curl_version_win();
         }
 
@@ -230,7 +225,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_easy_init()
         {
-            InitPlatformType();
             return PlatformType == NETPlatformType.Unix ? curl_easy_init_unix() : curl_easy_init_win();
         }
 
@@ -242,8 +236,6 @@ namespace CurlSharp
 
         internal static void curl_easy_cleanup(IntPtr pCurl)
         {
-            InitPlatformType();
-
             if (PlatformType == NETPlatformType.Unix)
                 curl_easy_cleanup_unix(pCurl);
             else
@@ -284,8 +276,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, IntPtr parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_setopt_unix(pCurl, opt, parm)
                 : curl_easy_setopt_win(pCurl, opt, parm);
@@ -299,8 +289,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, string parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_setopt_unix(pCurl, opt, parm)
                 : curl_easy_setopt_win(pCurl, opt, parm);
@@ -314,8 +302,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, byte[] parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_setopt_unix(pCurl, opt, parm)
                 : curl_easy_setopt_win(pCurl, opt, parm);
@@ -330,8 +316,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, long parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_setopt_unix(pCurl, opt, parm)
                 : curl_easy_setopt_win(pCurl, opt, parm);
@@ -345,8 +329,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, bool parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_setopt_unix(pCurl, opt, parm)
                 : curl_easy_setopt_win(pCurl, opt, parm);
@@ -364,8 +346,6 @@ namespace CurlSharp
         internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm)
         {
             CurlCode result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -391,8 +371,6 @@ namespace CurlSharp
         internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm)
         {
             CurlCode result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -416,8 +394,6 @@ namespace CurlSharp
         internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm)
         {
             CurlCode result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -440,8 +416,6 @@ namespace CurlSharp
         internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm)
         {
             CurlCode result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -464,8 +438,6 @@ namespace CurlSharp
         internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm)
         {
             CurlCode result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -501,9 +473,6 @@ namespace CurlSharp
             [In, Out] ref int max_fd)
         {
             CurlMultiCode result;
-            InitPlatformType();
-
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -607,8 +576,6 @@ namespace CurlSharp
             ref timeval timeout)
         {
             int result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -644,8 +611,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_perform(IntPtr pCurl)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix ? curl_easy_perform_unix(pCurl) : curl_easy_perform_win(pCurl);
         }
 
@@ -657,8 +622,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_easy_duphandle(IntPtr pCurl)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_duphandle_unix(pCurl)
                 : curl_easy_duphandle_win(pCurl);
@@ -672,8 +635,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_easy_strerror(CurlCode err)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix ? curl_easy_strerror_unix(err) : curl_easy_strerror_win(err);
         }
 
@@ -685,8 +646,6 @@ namespace CurlSharp
 
         internal static CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_easy_getinfo_unix(pCurl, info, ref pInfo)
                 : curl_easy_getinfo_win(pCurl, info, ref pInfo);
@@ -701,8 +660,6 @@ namespace CurlSharp
         internal static CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref double pInfo)
         {
             CurlCode result;
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -724,8 +681,6 @@ namespace CurlSharp
 
         internal static void curl_easy_reset(IntPtr pCurl)
         {
-            InitPlatformType();
-
             if (PlatformType == NETPlatformType.Unix)
                 curl_easy_reset_unix(pCurl);
             else
@@ -740,8 +695,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_multi_init()
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix ? curl_multi_init_unix() : curl_multi_init_win();
         }
 
@@ -753,8 +706,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_multi_cleanup(IntPtr pmulti)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_cleanup_unix(pmulti)
                 : curl_multi_cleanup_win(pmulti);
@@ -768,8 +719,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_multi_add_handle(IntPtr pmulti, IntPtr peasy)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_add_handle_unix(pmulti, peasy)
                 : curl_multi_add_handle_win(pmulti, peasy);
@@ -784,8 +733,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_multi_remove_handle(IntPtr pmulti, IntPtr peasy)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_remove_handle_unix(pmulti, peasy)
                 : curl_multi_remove_handle_win(pmulti, peasy);
@@ -800,8 +747,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_multi_setopt(IntPtr pmulti, CurlMultiOption opt, bool parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_setopt_unix(pmulti, opt, parm)
                 : curl_multi_setopt_win(pmulti, opt, parm);
@@ -816,8 +761,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_multi_setopt(IntPtr pmulti, CurlMultiOption opt, long parm)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_setopt_unix(pmulti, opt, parm)
                 : curl_multi_setopt_win(pmulti, opt, parm);
@@ -833,8 +776,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_multi_strerror(CurlMultiCode errorNum)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_strerror_unix(errorNum)
                 : curl_multi_strerror_win(errorNum);
@@ -848,8 +789,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_multi_perform(IntPtr pmulti, ref int runningHandles)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_multi_perform_unix(pmulti, ref runningHandles)
                 : curl_multi_perform_win(pmulti, ref runningHandles);
@@ -863,8 +802,6 @@ namespace CurlSharp
 
         internal static void curl_formfree(IntPtr pForm)
         {
-            InitPlatformType();
-
             switch (PlatformType)
             {
                 case NETPlatformType.Unix:
@@ -894,8 +831,6 @@ namespace CurlSharp
             int codeNext, IntPtr bufNext,
             int codeLast)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_formadd_unix(ref pHttppost, ref pLastPost,
                     codeFirst, bufFirst,
@@ -917,8 +852,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_share_init()
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix ? curl_share_init_unix() : curl_share_init_win();
         }
 
@@ -930,8 +863,6 @@ namespace CurlSharp
 
         internal static CurlShareCode curl_share_cleanup(IntPtr pShare)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_share_cleanup_unix(pShare)
                 : curl_share_cleanup_win(pShare);
@@ -945,8 +876,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_share_strerror(CurlShareCode errorCode)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_share_strerror_unix(errorCode)
                 : curl_share_strerror_win(errorCode);
@@ -963,8 +892,6 @@ namespace CurlSharp
 
         internal static CurlShareCode curl_share_setopt(IntPtr pShare, CurlShareOption optCode, IntPtr option)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_share_setopt_unix(pShare, optCode, option)
                 : curl_share_setopt_win(pShare, optCode, option);
@@ -980,8 +907,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_slist_append(IntPtr slist, string data)
         {
-            InitPlatformType();
-
             return PlatformType == NETPlatformType.Unix
                 ? curl_slist_append_unix(slist, data)
                 : curl_slist_append_win(slist, data);
@@ -995,7 +920,6 @@ namespace CurlSharp
 
         internal static void curl_slist_free_all(IntPtr pList)
         {
-            InitPlatformType();
             if (PlatformType == NETPlatformType.Unix) curl_slist_free_all_unix(pList);
             else curl_slist_free_all_win(pList);
         }
@@ -1008,18 +932,10 @@ namespace CurlSharp
 
         internal static IntPtr curl_version_info(CurlVersion ver)
         {
-            InitPlatformType();
             return PlatformType == NETPlatformType.Unix ? curl_version_info_unix(ver) : curl_version_info_win(ver);
         }
 
 #if  USE_LIBCURLSHIM
-
-        private static void ShimInitPlatform()
-        {
-            InitPlatformType();
-            if ((PlatformType == NETPlatformType.Unknown) || (PlatformType == NETPlatformType.Unix))
-                throw new InvalidOperationException("Can not run on other platform than Win NET");
-        }
 
         // libcurlshim imports
 
@@ -1028,7 +944,6 @@ namespace CurlSharp
 
         internal static void curl_shim_initialize()
         {
-            ShimInitPlatform();
             curl_shim_initialize_win();
         }
 
@@ -1037,7 +952,6 @@ namespace CurlSharp
 
         internal static void curl_shim_cleanup()
         {
-            ShimInitPlatform();
             curl_shim_cleanup_win();
         }
 
@@ -1047,7 +961,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_alloc_strings()
         {
-            ShimInitPlatform();
             return curl_shim_alloc_strings_win();
         }
 
@@ -1057,7 +970,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_add_string_to_slist(IntPtr pStrings, string str)
         {
-            ShimInitPlatform();
             return curl_shim_add_string_to_slist_win(pStrings, str);
         }
 
@@ -1067,7 +979,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_get_string_from_slist(IntPtr pSlist, ref IntPtr pStr)
         {
-            ShimInitPlatform();
             return curl_shim_get_string_from_slist_win(pSlist, ref pStr);
         }
 
@@ -1077,7 +988,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_add_string(IntPtr pStrings, string str)
         {
-            ShimInitPlatform();
             return curl_shim_add_string_win(pStrings, str);
         }
 
@@ -1087,7 +997,6 @@ namespace CurlSharp
 
         internal static void curl_shim_free_strings(IntPtr pStrings)
         {
-            ShimInitPlatform();
             curl_shim_free_strings_win(pStrings);
         }
 
@@ -1115,8 +1024,6 @@ namespace CurlSharp
             _ShimSslCtxCallback pCtx,
             _ShimIoctlCallback pIoctl)
         {
-            ShimInitPlatform();
-
             return curl_shim_install_delegates_win(
                 pCurl,
                 pThis,
@@ -1135,7 +1042,6 @@ namespace CurlSharp
 
         internal static void curl_shim_cleanup_delegates(IntPtr pThis)
         {
-            ShimInitPlatform();
             curl_shim_cleanup_delegates_win(pThis);
         }
 
@@ -1159,7 +1065,6 @@ namespace CurlSharp
             ref int mn,
             ref int ss)
         {
-            ShimInitPlatform();
             curl_shim_get_file_time_win(unixTime, ref yy, ref mm, ref dd, ref hh, ref mn, ref ss);
         }
 
@@ -1169,7 +1074,6 @@ namespace CurlSharp
 
         internal static void curl_shim_free_slist(IntPtr p)
         {
-            ShimInitPlatform();
             curl_shim_free_slist_win(p);
         }
 
@@ -1179,7 +1083,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_alloc_fd_sets()
         {
-            ShimInitPlatform();
             return curl_shim_alloc_fd_sets_win();
         }
 
@@ -1189,7 +1092,6 @@ namespace CurlSharp
 
         internal static void curl_shim_free_fd_sets(IntPtr fdsets)
         {
-            ShimInitPlatform();
             curl_shim_free_fd_sets_win(fdsets);
         }
 
@@ -1198,7 +1100,6 @@ namespace CurlSharp
 
         internal static CurlMultiCode curl_shim_multi_fdset(IntPtr multi, IntPtr fdsets, ref int maxFD)
         {
-            ShimInitPlatform();
             return curl_shim_multi_fdset_win(multi, fdsets, ref maxFD);
         }
 
@@ -1207,7 +1108,6 @@ namespace CurlSharp
 
         internal static int curl_shim_select(int maxFD, IntPtr fdsets, int milliseconds)
         {
-            ShimInitPlatform();
             return curl_shim_select_win(maxFD, fdsets, milliseconds);
         }
 
@@ -1217,7 +1117,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_multi_info_read(IntPtr multi, ref int nMsgs)
         {
-            ShimInitPlatform();
             return curl_shim_multi_info_read_win(multi, ref nMsgs);
         }
 
@@ -1227,7 +1126,6 @@ namespace CurlSharp
 
         internal static void curl_shim_multi_info_free(IntPtr multiInfo)
         {
-            ShimInitPlatform();
             curl_shim_multi_info_free_win(multiInfo);
         }
 
@@ -1236,7 +1134,6 @@ namespace CurlSharp
 
         internal static int curl_shim_formadd(IntPtr[] ppForms, IntPtr[] pParams, int nParams)
         {
-            ShimInitPlatform();
             return curl_shim_formadd_win(ppForms, pParams, nParams);
         }
 
@@ -1254,7 +1151,6 @@ namespace CurlSharp
             _ShimLockCallback pLock,
             _ShimUnlockCallback pUnlock)
         {
-            ShimInitPlatform();
             return curl_shim_install_share_delegates_win(pShare, pThis, pLock, pUnlock);
         }
 
@@ -1264,7 +1160,6 @@ namespace CurlSharp
 
         internal static void curl_shim_cleanup_share_delegates(IntPtr pShare)
         {
-            ShimInitPlatform();
             curl_shim_cleanup_share_delegates_win(pShare);
         }
 
@@ -1274,7 +1169,6 @@ namespace CurlSharp
 
         internal static int curl_shim_get_version_int_value(IntPtr p, int offset)
         {
-            ShimInitPlatform();
             return curl_shim_get_version_int_value_win(p, offset);
         }
 
@@ -1284,7 +1178,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_get_version_char_ptr(IntPtr p, int offset)
         {
-            ShimInitPlatform();
             return curl_shim_get_version_char_ptr_win(p, offset);
         }
 
@@ -1294,7 +1187,6 @@ namespace CurlSharp
 
         internal static int curl_shim_get_number_of_protocols(IntPtr p, int offset)
         {
-            ShimInitPlatform();
             return curl_shim_get_number_of_protocols_win(p, offset);
         }
 
@@ -1304,7 +1196,6 @@ namespace CurlSharp
 
         internal static IntPtr curl_shim_get_protocol_string(IntPtr p, int offset, int index)
         {
-            ShimInitPlatform();
             return curl_shim_get_protocol_string_win(p, offset, index);
         }
 

--- a/CurlSharp/NativeMethods.cs
+++ b/CurlSharp/NativeMethods.cs
@@ -93,17 +93,17 @@ namespace CurlSharp
 
         #endregion
 
-        #region curl_escape
+        #region curl_easy_escape
 
         [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        public static extern IntPtr curl_escape(string url, int length);
+        public static extern IntPtr curl_easy_escape(IntPtr pEasy, string url, int length);
 
         #endregion
 
-        #region curl_unescape
+        #region curl_easy_unescape
 
         [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        public static extern IntPtr curl_unescape(string url, int length);
+        public static extern IntPtr curl_easy_unescape(IntPtr pEasy, string url, int inLength, out int outLength);
 
         #endregion
 

--- a/CurlSharp/NativeMethods.cs
+++ b/CurlSharp/NativeMethods.cs
@@ -988,17 +988,16 @@ namespace CurlSharp
         }
 
         [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlShareCode curl_slist_free_all_unix(IntPtr pList);
+        private static extern void curl_slist_free_all_unix(IntPtr pList);
 
         [DllImport(CURL_LIB_WIN, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlShareCode curl_slist_free_all_win(IntPtr pList);
+        private static extern void curl_slist_free_all_win(IntPtr pList);
 
-        internal static CurlShareCode curl_slist_free_all(IntPtr pList)
+        internal static void curl_slist_free_all(IntPtr pList)
         {
             InitPlatformType();
-            return PlatformType == NETPlatformType.Unix
-                ? curl_slist_free_all_unix(pList)
-                : curl_slist_free_all_win(pList);
+            if (PlatformType == NETPlatformType.Unix) curl_slist_free_all_unix(pList);
+            else curl_slist_free_all_win(pList);
         }
 
         [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_version_info", CallingConvention = CallingConvention.Cdecl)]

--- a/CurlSharp/NativeMethods.cs
+++ b/CurlSharp/NativeMethods.cs
@@ -32,11 +32,9 @@ namespace CurlSharp
     /// </summary>
     internal static unsafe class NativeMethods
     {
-        private const string CURL_LIB_WIN = "libcurl.dll"; // should be in amd64 directory
+        private const string LIBCURL = "libcurl";
 
-        private const string CURL_LIB_UNIX = "libcurl";
-
-        private const string CURLSHIM_LIB_WIN = "libcurlshim.dll";
+        private const string LIBCURLSHIM = "libcurlshim";
 
         private const string LIBC_LINUX = "libc";
 
@@ -128,125 +126,78 @@ namespace CurlSharp
             return type;
         }
 
-        // internal delegates from cURL
+        #region curl_global_init
 
-        // libcurl imports
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_global_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_global_init_unix(int flags);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_global_init(int flags);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_global_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_global_init_win(int flags);
+        #endregion
 
-        internal static CurlCode curl_global_init(int flags)
-        {
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    return curl_global_init_unix(flags);
-                default:
-                    return curl_global_init_win(flags);
-            }
-        }
+        #region curl_global_cleanup
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_global_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_global_cleanup_unix();
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_global_cleanup();
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_global_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_global_cleanup_win();
+        #endregion
 
-        internal static void curl_global_cleanup()
-        {
-            if (PlatformType == NETPlatformType.Unix)
-                curl_global_cleanup_unix();
-            else
-                curl_global_cleanup_win();
-        }
+        #region curl_escape
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_escape", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_escape_unix(string url, int length);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr curl_escape(string url, int length);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_escape", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_escape_win(string url, int length);
+        #endregion
 
-        internal static IntPtr curl_escape(string url, int length)
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_escape_unix(url, length) : curl_escape_win(url, length);
-        }
+        #region curl_unescape
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_unescape", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_unescape_unix(string url, int length);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr curl_unescape(string url, int length);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_unescape", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_unescape_win(string url, int length);
+        #endregion
 
+        #region curl_free
 
-        internal static IntPtr curl_unescape(string url, int length)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_unescape_unix(url, length)
-                : curl_unescape_win(url, length);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_free(IntPtr p);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_free", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_free_unix(IntPtr p);
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_free", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_free_win(IntPtr p);
+        #region curl_version
 
-        internal static void curl_free(IntPtr p)
-        {
-            if (PlatformType == NETPlatformType.Unix)
-                curl_free_unix(p);
-            else
-                curl_free_win(p);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_version();
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_version", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_version_unix();
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_version", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_version_win();
+        #region curl_version_info
 
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_version_info(CurlVersion ver);
 
-        internal static IntPtr curl_version()
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_version_unix() : curl_version_win();
-        }
+        #endregion
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_easy_init_unix();
+        #region curl_easy_init
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_easy_init_win();
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_easy_init();
 
-        internal static IntPtr curl_easy_init()
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_easy_init_unix() : curl_easy_init_win();
-        }
+        #endregion
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_easy_cleanup_unix(IntPtr pCurl);
+        #region curl_easy_cleanup
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_easy_cleanup_win(IntPtr pCurl);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_easy_cleanup(IntPtr pCurl);
 
-        internal static void curl_easy_cleanup(IntPtr pCurl)
-        {
-            if (PlatformType == NETPlatformType.Unix)
-                curl_easy_cleanup_unix(pCurl);
-            else
-                curl_easy_cleanup_win(pCurl);
-        }
+        #endregion
+
+        #region curl_easy_setopt
+
+        #region Delegates
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int _CurlGenericCallback(IntPtr ptr, int sz, int nmemb, IntPtr userdata);
+        public delegate int _CurlGenericCallback(IntPtr ptr, int sz, int nmemb, IntPtr userdata);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int _CurlProgressCallback(
+        public delegate int _CurlProgressCallback(
             IntPtr extraData,
             double dlTotal,
             double dlNow,
@@ -254,7 +205,7 @@ namespace CurlSharp
             double ulNow);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int _CurlDebugCallback(
+        public delegate int _CurlDebugCallback(
             IntPtr ptrCurl,
             CurlInfoType infoType,
             string message,
@@ -262,247 +213,162 @@ namespace CurlSharp
             IntPtr ptrUserData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int _CurlSslCtxCallback(IntPtr ctx, IntPtr parm);
+        public delegate int _CurlSslCtxCallback(IntPtr ctx, IntPtr parm);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate CurlIoError _CurlIoctlCallback(CurlIoCommand cmd, IntPtr parm);
+        public delegate CurlIoError _CurlIoctlCallback(CurlIoCommand cmd, IntPtr parm);
 
-        // curl_easy_setopt() overloads
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_unix(IntPtr pCurl, CurlOption opt, IntPtr parm);
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_win(IntPtr pCurl, CurlOption opt, IntPtr parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, IntPtr parm);
 
-        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, IntPtr parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_setopt_unix(pCurl, opt, parm)
-                : curl_easy_setopt_win(pCurl, opt, parm);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, string parm);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_unix(IntPtr pCurl, CurlOption opt, string parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, byte[] parm);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_win(IntPtr pCurl, CurlOption opt, string parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, long parm);
 
-        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, string parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_setopt_unix(pCurl, opt, parm)
-                : curl_easy_setopt_win(pCurl, opt, parm);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, bool parm);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_unix(IntPtr pCurl, CurlOption opt, byte[] parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_win(IntPtr pCurl, CurlOption opt, byte[] parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm);
 
-        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, byte[] parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_setopt_unix(pCurl, opt, parm)
-                : curl_easy_setopt_win(pCurl, opt, parm);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_unix(IntPtr pCurl, CurlOption opt, long parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_win(IntPtr pCurl, CurlOption opt, long parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
 
+        #endregion
 
-        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, long parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_setopt_unix(pCurl, opt, parm)
-                : curl_easy_setopt_win(pCurl, opt, parm);
-        }
+        #region curl_easy_perform
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_unix(IntPtr pCurl, CurlOption opt, bool parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_perform(IntPtr pCurl);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_win(IntPtr pCurl, CurlOption opt, bool parm);
+        #endregion
 
-        internal static CurlCode curl_easy_setopt(IntPtr pCurl, CurlOption opt, bool parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_setopt_unix(pCurl, opt, parm)
-                : curl_easy_setopt_win(pCurl, opt, parm);
-        }
+        #region curl_easy_duphandle
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_unix(
-            IntPtr pCurl,
-            CurlOption opt,
-            _CurlGenericCallback parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_easy_duphandle(IntPtr pCurl);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_win(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm);
+        #endregion
 
-        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlGenericCallback parm)
-        {
-            CurlCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_easy_setopt_cb_unix(pCurl, opt, parm);
-                    break;
-                default:
-                    result = curl_easy_setopt_cb_win(pCurl, opt, parm);
-                    break;
-            }
+        #region curl_easy_strerror
 
-            return result;
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_easy_strerror(CurlCode err);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_unix(
-            IntPtr pCurl,
-            CurlOption opt,
-            _CurlProgressCallback parm);
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_win(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm);
+        #region curl_easy_getinfo
 
-        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlProgressCallback parm)
-        {
-            CurlCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_easy_setopt_cb_unix(pCurl, opt, parm);
-                    break;
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
 
-                default:
-                    result = curl_easy_setopt_cb_win(pCurl, opt, parm);
-                    break;
-            }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref double dblVal);
 
-            return result;
-        }
+        #endregion
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_unix(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
+        #region curl_easy_reset
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_win(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_easy_reset(IntPtr pCurl);
 
-        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlDebugCallback parm)
-        {
-            CurlCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_easy_setopt_cb_unix(pCurl, opt, parm);
-                    break;
-                default:
-                    result = curl_easy_setopt_cb_win(pCurl, opt, parm);
-                    break;
-            }
+        #endregion
 
-            return result;
-        }
+        #region curl_multi_init
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_unix(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_multi_init();
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_win(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm);
+        #endregion
 
-        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlSslCtxCallback parm)
-        {
-            CurlCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_easy_setopt_cb_unix(pCurl, opt, parm);
-                    break;
-                default:
-                    result = curl_easy_setopt_cb_win(pCurl, opt, parm);
-                    break;
-            }
+        #region curl_multi_cleanup
 
-            return result;
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_cleanup(IntPtr pmulti);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_unix(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_setopt_cb_win(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm);
+        #region curl_multi_add_handle
 
-        internal static CurlCode curl_easy_setopt_cb(IntPtr pCurl, CurlOption opt, _CurlIoctlCallback parm)
-        {
-            CurlCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_easy_setopt_cb_unix(pCurl, opt, parm);
-                    break;
-                default:
-                    result = curl_easy_setopt_cb_win(pCurl, opt, parm);
-                    break;
-            }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_add_handle(IntPtr pmulti, IntPtr peasy);
 
-            return result;
-        }
+        #endregion
+
+        #region curl_multi_remove_handle
+
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_remove_handle(IntPtr pmulti, IntPtr peasy);
+
+        #endregion
+
+        #region curl_multi_setopt
+
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_setopt(IntPtr pmulti, CurlMultiOption opt, bool parm);
+
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_setopt(IntPtr pmulti, CurlMultiOption opt, long parm);
+
+        #endregion
+
+        #region curl_multi_strerror
+
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_multi_strerror(CurlMultiCode errorNum);
+
+        #endregion
+
+        #region curl_multi_perform
+
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_perform(IntPtr pmulti, ref int runningHandles);
+
+        #endregion
 
 #if !USE_LIBCURLSHIM
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_fdset_unix(IntPtr pmulti,
-            [In, Out] ref fd_set read_fd_set,
-            [In, Out] ref fd_set write_fd_set,
-            [In, Out] ref fd_set exc_fd_set,
-            [In, Out] ref int max_fd);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_fdset_win(IntPtr pmulti,
-            [In, Out] ref fd_set read_fd_set,
-            [In, Out] ref fd_set write_fd_set,
-            [In, Out] ref fd_set exc_fd_set,
-            [In, Out] ref int max_fd);
+        #region curl_multi_fdset
 
-        internal static CurlMultiCode curl_multi_fdset(IntPtr pmulti,
-            [In, Out] ref fd_set read_fd_set,
-            [In, Out] ref fd_set write_fd_set,
-            [In, Out] ref fd_set exc_fd_set,
-            [In, Out] ref int max_fd)
-        {
-            CurlMultiCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_multi_fdset_unix(pmulti, ref read_fd_set,
-                        ref write_fd_set, ref exc_fd_set, ref max_fd);
-                    break;
-                default:
-                    result = curl_multi_fdset_win(pmulti, ref read_fd_set,
-                        ref write_fd_set, ref exc_fd_set, ref max_fd);
-                    break;
-            }
-            return result;
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_multi_fdset(IntPtr pmulti,
+            [In] [Out] ref fd_set read_fd_set,
+            [In] [Out] ref fd_set write_fd_set,
+            [In] [Out] ref fd_set exc_fd_set,
+            [In] [Out] ref int max_fd);
 
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct fd_set
+        public struct fd_set
         {
-            internal uint fd_count;
+            public uint fd_count;
 
-            // [MarshalAs(UnmanagedType.ByValArray, SizeConst = FD_SETSIZE)] internal IntPtr[] fd_array;
-            internal fixed uint fd_array [FD_SETSIZE];
+            // [MarshalAs(UnmanagedType.ByValArray, SizeConst = FD_SETSIZE)] public IntPtr[] fd_array;
+            public fixed uint fd_array[FD_SETSIZE];
 
-            internal const int FD_SETSIZE = 64;
+            public const int FD_SETSIZE = 64;
 
-            internal void Cleanup()
+            public void Cleanup()
             {
                 // fd_array = null;
             }
 
-            internal static fd_set Create()
+            public static fd_set Create()
             {
                 return new fd_set
                 {
@@ -511,7 +377,7 @@ namespace CurlSharp
                 };
             }
 
-            internal static fd_set Create(IntPtr socket)
+            public static fd_set Create(IntPtr socket)
             {
                 var handle = Create();
                 handle.fd_count = 1;
@@ -520,32 +386,38 @@ namespace CurlSharp
             }
         }
 
-        internal static unsafe void FD_ZERO(fd_set fds)
+        public static void FD_ZERO(fd_set fds)
         {
             for (var i = 0; i < fd_set.FD_SETSIZE; i++)
+            {
                 fds.fd_array[i] = 0;
+            }
             fds.fd_count = 0;
         }
 
+        #endregion
+
+        #region select
+
         [StructLayout(LayoutKind.Sequential)]
-        internal struct timeval
+        public struct timeval
         {
             /// <summary>
             ///     Time interval, in seconds.
             /// </summary>
-            internal int tv_sec;
+            public int tv_sec;
 
             /// <summary>
             ///     Time interval, in microseconds.
             /// </summary>
-            internal int tv_usec;
+            public int tv_usec;
 
-            internal static timeval Create(int milliseconds)
+            public static timeval Create(int milliseconds)
             {
                 return new timeval
                 {
-                    tv_sec = milliseconds/1000,
-                    tv_usec = milliseconds%1000*1000
+                    tv_sec = milliseconds / 1000,
+                    tv_usec = milliseconds % 1000 * 1000
                 };
             }
         }
@@ -553,26 +425,24 @@ namespace CurlSharp
         [DllImport(LIBC_LINUX, EntryPoint = "select")]
         private static extern int select_unix(
             int nfds, // number of sockets, (ignored in winsock)
-            [In, Out] ref fd_set readfds, // read sockets to watch
-            [In, Out] ref fd_set writefds, // write sockets to watch
-            [In, Out] ref fd_set exceptfds, // error sockets to watch
+            [In] [Out] ref fd_set readfds, // read sockets to watch
+            [In] [Out] ref fd_set writefds, // write sockets to watch
+            [In] [Out] ref fd_set exceptfds, // error sockets to watch
             ref timeval timeout);
-
 
         [DllImport(WINSOCK_LIB, EntryPoint = "select")]
         private static extern int select_win(
             int nfds, // number of sockets, (ignored in winsock)
-            [In, Out] ref fd_set readfds, // read sockets to watch
-            [In, Out] ref fd_set writefds, // write sockets to watch
-            [In, Out] ref fd_set exceptfds, // error sockets to watch
+            [In] [Out] ref fd_set readfds, // read sockets to watch
+            [In] [Out] ref fd_set writefds, // write sockets to watch
+            [In] [Out] ref fd_set exceptfds, // error sockets to watch
             ref timeval timeout);
 
-
-        internal static int select(
+        public static int select(
             int nfds, // number of sockets, (ignored in winsock)
-            [In, Out] ref fd_set readfds, // read sockets to watch
-            [In, Out] ref fd_set writefds, // write sockets to watch
-            [In, Out] ref fd_set exceptfds, // error sockets to watch
+            [In] [Out] ref fd_set readfds, // read sockets to watch
+            [In] [Out] ref fd_set writefds, // write sockets to watch
+            [In] [Out] ref fd_set exceptfds, // error sockets to watch
             ref timeval timeout)
         {
             int result;
@@ -598,411 +468,103 @@ namespace CurlSharp
             return result;
         }
 
-
-        // [DllImport(WINSOCK_LIB, EntryPoint = "select")]
-        // internal static int select(int ndfs, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timeval* timeout);
-#endif
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_perform", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_perform_unix(IntPtr pCurl);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_perform", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_perform_win(IntPtr pCurl);
-
-        internal static CurlCode curl_easy_perform(IntPtr pCurl)
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_easy_perform_unix(pCurl) : curl_easy_perform_win(pCurl);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_duphandle", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_easy_duphandle_unix(IntPtr pCurl);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_duphandle", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_easy_duphandle_win(IntPtr pCurl);
-
-        internal static IntPtr curl_easy_duphandle(IntPtr pCurl)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_duphandle_unix(pCurl)
-                : curl_easy_duphandle_win(pCurl);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_strerror", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_easy_strerror_unix(CurlCode err);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_strerror", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_easy_strerror_win(CurlCode err);
-
-        internal static IntPtr curl_easy_strerror(CurlCode err)
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_easy_strerror_unix(err) : curl_easy_strerror_win(err);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_getinfo_unix(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_getinfo_win(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo);
-
-        internal static CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref IntPtr pInfo)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_easy_getinfo_unix(pCurl, info, ref pInfo)
-                : curl_easy_getinfo_win(pCurl, info, ref pInfo);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_getinfo_unix(IntPtr pCurl, CurlInfo info, ref double dblVal);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_getinfo", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlCode curl_easy_getinfo_win(IntPtr pCurl, CurlInfo info, ref double dblVal);
-
-        internal static CurlCode curl_easy_getinfo(IntPtr pCurl, CurlInfo info, ref double pInfo)
-        {
-            CurlCode result;
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    result = curl_easy_getinfo_unix(pCurl, info, ref pInfo);
-                    break;
-                default:
-                    result = curl_easy_getinfo_win(pCurl, info, ref pInfo);
-                    break;
-            }
-
-            return result;
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_easy_reset", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_easy_reset_unix(IntPtr pCurl);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_easy_reset", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_easy_reset_win(IntPtr pCurl);
-
-        internal static void curl_easy_reset(IntPtr pCurl)
-        {
-            if (PlatformType == NETPlatformType.Unix)
-                curl_easy_reset_unix(pCurl);
-            else
-                curl_easy_reset_win(pCurl);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_multi_init_unix();
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_multi_init_win();
-
-        internal static IntPtr curl_multi_init()
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_multi_init_unix() : curl_multi_init_win();
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_cleanup_unix(IntPtr pmulti);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_cleanup_win(IntPtr pmulti);
-
-        internal static CurlMultiCode curl_multi_cleanup(IntPtr pmulti)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_cleanup_unix(pmulti)
-                : curl_multi_cleanup_win(pmulti);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_add_handle", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_add_handle_unix(IntPtr pmulti, IntPtr peasy);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_add_handle", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_add_handle_win(IntPtr pmulti, IntPtr peasy);
-
-        internal static CurlMultiCode curl_multi_add_handle(IntPtr pmulti, IntPtr peasy)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_add_handle_unix(pmulti, peasy)
-                : curl_multi_add_handle_win(pmulti, peasy);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_remove_handle", CallingConvention = CallingConvention.Cdecl)
-        ]
-        private static extern CurlMultiCode curl_multi_remove_handle_unix(IntPtr pmulti, IntPtr peasy);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_remove_handle", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_remove_handle_win(IntPtr pmulti, IntPtr peasy);
-
-        internal static CurlMultiCode curl_multi_remove_handle(IntPtr pmulti, IntPtr peasy)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_remove_handle_unix(pmulti, peasy)
-                : curl_multi_remove_handle_win(pmulti, peasy);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_setopt", CallingConvention = CallingConvention.Cdecl)
-        ]
-        private static extern CurlMultiCode curl_multi_setopt_unix(IntPtr pmulti, CurlMultiOption opt, bool parm);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_setopt_win(IntPtr pmulti, CurlMultiOption opt, bool parm);
-
-        internal static CurlMultiCode curl_multi_setopt(IntPtr pmulti, CurlMultiOption opt, bool parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_setopt_unix(pmulti, opt, parm)
-                : curl_multi_setopt_win(pmulti, opt, parm);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_setopt", CallingConvention = CallingConvention.Cdecl)
-        ]
-        private static extern CurlMultiCode curl_multi_setopt_unix(IntPtr pmulti, CurlMultiOption opt, long parm);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_setopt_win(IntPtr pmulti, CurlMultiOption opt, long parm);
-
-        internal static CurlMultiCode curl_multi_setopt(IntPtr pmulti, CurlMultiOption opt, long parm)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_setopt_unix(pmulti, opt, parm)
-                : curl_multi_setopt_win(pmulti, opt, parm);
-        }
-
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_strerror", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_multi_strerror_unix(CurlMultiCode errorNum);
-
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_strerror", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_multi_strerror_win(CurlMultiCode errorNum);
-
-        internal static IntPtr curl_multi_strerror(CurlMultiCode errorNum)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_strerror_unix(errorNum)
-                : curl_multi_strerror_win(errorNum);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_multi_perform", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_perform_unix(IntPtr pmulti, ref int runningHandles);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_multi_perform", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_multi_perform_win(IntPtr pmulti, ref int runningHandles);
-
-        internal static CurlMultiCode curl_multi_perform(IntPtr pmulti, ref int runningHandles)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_multi_perform_unix(pmulti, ref runningHandles)
-                : curl_multi_perform_win(pmulti, ref runningHandles);
-        }
-
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_formfree", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_formfree_unix(IntPtr pForm);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_formfree", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_formfree_win(IntPtr pForm);
-
-        internal static void curl_formfree(IntPtr pForm)
-        {
-            switch (PlatformType)
-            {
-                case NETPlatformType.Unix:
-                    curl_formfree_unix(pForm);
-                    break;
-                default:
-                    curl_formfree_win(pForm);
-                    break;
-            }
-        }
-
-#if !USE_LIBCURLSHIM
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_formadd", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_formadd_unix(ref IntPtr pHttppost, ref IntPtr pLastPost,
-            int codeFirst, IntPtr bufFirst,
-            int codeNext, IntPtr bufNext,
-            int codeLast);
-
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_formadd", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_formadd_win(ref IntPtr pHttppost, ref IntPtr pLastPost,
-            int codeFirst, IntPtr bufFirst,
-            int codeNext, IntPtr bufNext,
-            int codeLast);
-
-        internal static int curl_formadd(ref IntPtr pHttppost, ref IntPtr pLastPost,
-            int codeFirst, IntPtr bufFirst,
-            int codeNext, IntPtr bufNext,
-            int codeLast)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_formadd_unix(ref pHttppost, ref pLastPost,
-                    codeFirst, bufFirst,
-                    codeNext, bufNext,
-                    codeLast)
-                : curl_formadd_win(ref pHttppost, ref pLastPost,
-                    codeFirst, bufFirst,
-                    codeNext, bufNext,
-                    codeLast);
-        }
+        #endregion
 
 #endif
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_share_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_share_init_unix();
+        #region curl_share_init
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_share_init", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_share_init_win();
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_share_init();
 
-        internal static IntPtr curl_share_init()
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_share_init_unix() : curl_share_init_win();
-        }
+        #endregion
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_share_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlShareCode curl_share_cleanup_unix(IntPtr pShare);
+        #region curl_share_cleanup
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_share_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlShareCode curl_share_cleanup_win(IntPtr pShare);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlShareCode curl_share_cleanup(IntPtr pShare);
 
-        internal static CurlShareCode curl_share_cleanup(IntPtr pShare)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_share_cleanup_unix(pShare)
-                : curl_share_cleanup_win(pShare);
-        }
+        #endregion
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_share_strerror", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_share_strerror_unix(CurlShareCode errorCode);
+        #region curl_share_strerror
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_share_strerror", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_share_strerror_win(CurlShareCode errorCode);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_share_strerror(CurlShareCode errorCode);
 
-        internal static IntPtr curl_share_strerror(CurlShareCode errorCode)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_share_strerror_unix(errorCode)
-                : curl_share_strerror_win(errorCode);
-        }
+        #endregion
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_share_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlShareCode curl_share_setopt_unix(
+        #region curl_share_setopt
+
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlShareCode curl_share_setopt(
             IntPtr pShare,
             CurlShareOption optCode,
             IntPtr option);
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_share_setopt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlShareCode curl_share_setopt_win(IntPtr pShare, CurlShareOption optCode, IntPtr option);
+        #endregion
 
-        internal static CurlShareCode curl_share_setopt(IntPtr pShare, CurlShareOption optCode, IntPtr option)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_share_setopt_unix(pShare, optCode, option)
-                : curl_share_setopt_win(pShare, optCode, option);
-        }
+        #region curl_formadd
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_slist_append", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_slist_append_unix(IntPtr slist, string data);
+#if !USE_LIBCURLSHIM
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_slist_append", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_slist_append_win(IntPtr slist, string data);
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_formadd(ref IntPtr pHttppost, ref IntPtr pLastPost,
+            int codeFirst, IntPtr bufFirst,
+            int codeNext, IntPtr bufNext,
+            int codeLast);
 
-        internal static IntPtr curl_slist_append(IntPtr slist, string data)
-        {
-            return PlatformType == NETPlatformType.Unix
-                ? curl_slist_append_unix(slist, data)
-                : curl_slist_append_win(slist, data);
-        }
+#endif
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_slist_free_all_unix(IntPtr pList);
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_slist_free_all", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_slist_free_all_win(IntPtr pList);
+        #region curl_formfree
 
-        internal static void curl_slist_free_all(IntPtr pList)
-        {
-            if (PlatformType == NETPlatformType.Unix) curl_slist_free_all_unix(pList);
-            else curl_slist_free_all_win(pList);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_formfree(IntPtr pForm);
 
-        [DllImport(CURL_LIB_UNIX, EntryPoint = "curl_version_info", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_version_info_unix(CurlVersion ver);
+        #endregion
 
-        [DllImport(CURL_LIB_WIN, EntryPoint = "curl_version_info", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_version_info_win(CurlVersion ver);
+        #region curl_slist_append
 
-        internal static IntPtr curl_version_info(CurlVersion ver)
-        {
-            return PlatformType == NETPlatformType.Unix ? curl_version_info_unix(ver) : curl_version_info_win(ver);
-        }
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr curl_slist_append(IntPtr slist, string data);
 
-#if  USE_LIBCURLSHIM
+        #endregion
 
-        // libcurlshim imports
+        #region curl_slist_free_all
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_initialize", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_shim_initialize_win();
+        [DllImport(LIBCURL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_slist_free_all(IntPtr pList);
 
-        internal static void curl_shim_initialize()
-        {
-            curl_shim_initialize_win();
-        }
+        #endregion
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_cleanup", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_shim_cleanup_win();
+#if USE_LIBCURLSHIM
 
-        internal static void curl_shim_cleanup()
-        {
-            curl_shim_cleanup_win();
-        }
+        #region libcurlshim imports
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_alloc_strings", CallingConvention = CallingConvention.Cdecl
-         )]
-        private static extern IntPtr curl_shim_alloc_strings_win();
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_initialize();
 
-        internal static IntPtr curl_shim_alloc_strings()
-        {
-            return curl_shim_alloc_strings_win();
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_cleanup();
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_add_string_to_slist",
-             CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_shim_add_string_to_slist_win(IntPtr pStrings, string str);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_shim_alloc_strings();
 
-        internal static IntPtr curl_shim_add_string_to_slist(IntPtr pStrings, string str)
-        {
-            return curl_shim_add_string_to_slist_win(pStrings, str);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr curl_shim_add_string_to_slist(IntPtr pStrings, string str);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_string_from_slist",
-             CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_shim_get_string_from_slist_win(IntPtr pSlist, ref IntPtr pStr);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr curl_shim_get_string_from_slist(IntPtr pSlist, ref IntPtr pStr);
 
-        internal static IntPtr curl_shim_get_string_from_slist(IntPtr pSlist, ref IntPtr pStr)
-        {
-            return curl_shim_get_string_from_slist_win(pSlist, ref pStr);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr curl_shim_add_string(IntPtr pStrings, string str);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_add_string", CallingConvention = CallingConvention.Cdecl,
-             CharSet = CharSet.Ansi)]
-        private static extern IntPtr curl_shim_add_string_win(IntPtr pStrings, string str);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_free_strings(IntPtr pStrings);
 
-        internal static IntPtr curl_shim_add_string(IntPtr pStrings, string str)
-        {
-            return curl_shim_add_string_win(pStrings, str);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_free_strings", CallingConvention = CallingConvention.Cdecl)
-        ]
-        private static extern void curl_shim_free_strings_win(IntPtr pStrings);
-
-        internal static void curl_shim_free_strings(IntPtr pStrings)
-        {
-            curl_shim_free_strings_win(pStrings);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_install_delegates",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_shim_install_delegates_win(
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_shim_install_delegates(
             IntPtr pCurl,
             IntPtr pThis,
             _ShimWriteCallback pWrite,
@@ -1013,41 +575,11 @@ namespace CurlSharp
             _ShimSslCtxCallback pCtx,
             _ShimIoctlCallback pIoctl);
 
-        internal static int curl_shim_install_delegates(
-            IntPtr pCurl,
-            IntPtr pThis,
-            _ShimWriteCallback pWrite,
-            _ShimReadCallback pRead,
-            _ShimProgressCallback pProgress,
-            _ShimDebugCallback pDebug,
-            _ShimHeaderCallback pHeader,
-            _ShimSslCtxCallback pCtx,
-            _ShimIoctlCallback pIoctl)
-        {
-            return curl_shim_install_delegates_win(
-                pCurl,
-                pThis,
-                pWrite,
-                pRead,
-                pProgress,
-                pDebug,
-                pHeader,
-                pCtx,
-                pIoctl);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_cleanup_delegates(IntPtr pThis);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_cleanup_delegates",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_shim_cleanup_delegates_win(IntPtr pThis);
-
-        internal static void curl_shim_cleanup_delegates(IntPtr pThis)
-        {
-            curl_shim_cleanup_delegates_win(pThis);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_file_time", CallingConvention = CallingConvention.Cdecl
-         )]
-        private static extern void curl_shim_get_file_time_win(
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_get_file_time(
             int unixTime,
             ref int yy,
             ref int mm,
@@ -1056,171 +588,77 @@ namespace CurlSharp
             ref int mn,
             ref int ss);
 
-        internal static void curl_shim_get_file_time(
-            int unixTime,
-            ref int yy,
-            ref int mm,
-            ref int dd,
-            ref int hh,
-            ref int mn,
-            ref int ss)
-        {
-            curl_shim_get_file_time_win(unixTime, ref yy, ref mm, ref dd, ref hh, ref mn, ref ss);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_free_slist(IntPtr p);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_file_time", CallingConvention = CallingConvention.Cdecl
-         )]
-        private static extern void curl_shim_free_slist_win(IntPtr p);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_shim_alloc_fd_sets();
 
-        internal static void curl_shim_free_slist(IntPtr p)
-        {
-            curl_shim_free_slist_win(p);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_free_fd_sets(IntPtr fdsets);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_alloc_fd_sets", CallingConvention = CallingConvention.Cdecl
-         )]
-        private static extern IntPtr curl_shim_alloc_fd_sets_win();
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CurlMultiCode curl_shim_multi_fdset(IntPtr multi, IntPtr fdsets, ref int maxFD);
 
-        internal static IntPtr curl_shim_alloc_fd_sets()
-        {
-            return curl_shim_alloc_fd_sets_win();
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_shim_select(int maxFD, IntPtr fdsets, int milliseconds);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_free_fd_sets", CallingConvention = CallingConvention.Cdecl)
-        ]
-        private static extern void curl_shim_free_fd_sets_win(IntPtr fdsets);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_shim_multi_info_read(IntPtr multi, ref int nMsgs);
 
-        internal static void curl_shim_free_fd_sets(IntPtr fdsets)
-        {
-            curl_shim_free_fd_sets_win(fdsets);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_multi_info_free(IntPtr multiInfo);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_multi_fdset", CallingConvention = CallingConvention.Cdecl)]
-        private static extern CurlMultiCode curl_shim_multi_fdset_win(IntPtr multi, IntPtr fdsets, ref int maxFD);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_shim_formadd(IntPtr[] ppForms, IntPtr[] pParams, int nParams);
 
-        internal static CurlMultiCode curl_shim_multi_fdset(IntPtr multi, IntPtr fdsets, ref int maxFD)
-        {
-            return curl_shim_multi_fdset_win(multi, fdsets, ref maxFD);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_select", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_shim_select_win(int maxFD, IntPtr fdsets, int milliseconds);
-
-        internal static int curl_shim_select(int maxFD, IntPtr fdsets, int milliseconds)
-        {
-            return curl_shim_select_win(maxFD, fdsets, milliseconds);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_multi_info_read",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_shim_multi_info_read_win(IntPtr multi, ref int nMsgs);
-
-        internal static IntPtr curl_shim_multi_info_read(IntPtr multi, ref int nMsgs)
-        {
-            return curl_shim_multi_info_read_win(multi, ref nMsgs);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_multi_info_free",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_shim_multi_info_free_win(IntPtr multiInfo);
-
-        internal static void curl_shim_multi_info_free(IntPtr multiInfo)
-        {
-            curl_shim_multi_info_free_win(multiInfo);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_formadd", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_shim_formadd_win(IntPtr[] ppForms, IntPtr[] pParams, int nParams);
-
-        internal static int curl_shim_formadd(IntPtr[] ppForms, IntPtr[] pParams, int nParams)
-        {
-            return curl_shim_formadd_win(ppForms, pParams, nParams);
-        }
-
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_install_share_delegates",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_shim_install_share_delegates_win(
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_shim_install_share_delegates(
             IntPtr pShare,
             IntPtr pThis,
             _ShimLockCallback pLock,
             _ShimUnlockCallback pUnlock);
 
-        internal static int curl_shim_install_share_delegates(
-            IntPtr pShare,
-            IntPtr pThis,
-            _ShimLockCallback pLock,
-            _ShimUnlockCallback pUnlock)
-        {
-            return curl_shim_install_share_delegates_win(pShare, pThis, pLock, pUnlock);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void curl_shim_cleanup_share_delegates(IntPtr pShare);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "url_shim_cleanup_share_delegates",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern void curl_shim_cleanup_share_delegates_win(IntPtr pShare);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_shim_get_version_int_value(IntPtr p, int offset);
 
-        internal static void curl_shim_cleanup_share_delegates(IntPtr pShare)
-        {
-            curl_shim_cleanup_share_delegates_win(pShare);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_shim_get_version_char_ptr(IntPtr p, int offset);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_version_int_value",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_shim_get_version_int_value_win(IntPtr p, int offset);
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int curl_shim_get_number_of_protocols(IntPtr p, int offset);
 
-        internal static int curl_shim_get_version_int_value(IntPtr p, int offset)
-        {
-            return curl_shim_get_version_int_value_win(p, offset);
-        }
+        [DllImport(LIBCURLSHIM, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr curl_shim_get_protocol_string(IntPtr p, int offset, int index);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_version_char_ptr",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_shim_get_version_char_ptr_win(IntPtr p, int offset);
+        public delegate void _ShimLockCallback(int data, int access, IntPtr userPtr);
 
-        internal static IntPtr curl_shim_get_version_char_ptr(IntPtr p, int offset)
-        {
-            return curl_shim_get_version_char_ptr_win(p, offset);
-        }
+        public delegate void _ShimUnlockCallback(int data, IntPtr userPtr);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_number_of_protocols",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern int curl_shim_get_number_of_protocols_win(IntPtr p, int offset);
+        public delegate int _ShimDebugCallback(CurlInfoType infoType, IntPtr msgBuf, int msgBufSize, IntPtr parm);
 
-        internal static int curl_shim_get_number_of_protocols(IntPtr p, int offset)
-        {
-            return curl_shim_get_number_of_protocols_win(p, offset);
-        }
+        public delegate int _ShimHeaderCallback(IntPtr buf, int sz, int nmemb, IntPtr stream);
 
-        [DllImport(CURLSHIM_LIB_WIN, EntryPoint = "curl_shim_get_protocol_string",
-             CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr curl_shim_get_protocol_string_win(IntPtr p, int offset, int index);
+        public delegate CurlIoError _ShimIoctlCallback(CurlIoCommand cmd, IntPtr parm);
 
-        internal static IntPtr curl_shim_get_protocol_string(IntPtr p, int offset, int index)
-        {
-            return curl_shim_get_protocol_string_win(p, offset, index);
-        }
-
-        internal delegate void _ShimLockCallback(int data, int access, IntPtr userPtr);
-
-        internal delegate void _ShimUnlockCallback(int data, IntPtr userPtr);
-
-        internal delegate int _ShimDebugCallback(CurlInfoType infoType, IntPtr msgBuf, int msgBufSize, IntPtr parm);
-
-        internal delegate int _ShimHeaderCallback(IntPtr buf, int sz, int nmemb, IntPtr stream);
-
-        internal delegate CurlIoError _ShimIoctlCallback(CurlIoCommand cmd, IntPtr parm);
-
-        internal delegate int _ShimProgressCallback(
+        public delegate int _ShimProgressCallback(
             IntPtr parm,
             double dlTotal,
             double dlNow,
             double ulTotal,
             double ulNow);
 
-        internal delegate int _ShimReadCallback(IntPtr buf, int sz, int nmemb, IntPtr parm);
+        public delegate int _ShimReadCallback(IntPtr buf, int sz, int nmemb, IntPtr parm);
 
-        internal delegate int _ShimSslCtxCallback(IntPtr ctx, IntPtr parm);
+        public delegate int _ShimSslCtxCallback(IntPtr ctx, IntPtr parm);
 
-        internal delegate int _ShimWriteCallback(IntPtr buf, int sz, int nmemb, IntPtr parm);
+        public delegate int _ShimWriteCallback(IntPtr buf, int sz, int nmemb, IntPtr parm);
+
+        #endregion
+
 #endif
     }
 }


### PR DESCRIPTION
Changes:
* We don't have to specify both `libcurl.dll` and `libcurl` in P/Invoke declarations. On Windows it automatically adds `.dll` suffix to library name, so `libcurl` is enough. Therefore we don't need two native extern functions and third wrapper choosing one of two.
* Removed `EntryPoint` property of `DllImport` where method name is same as entry point.
* Platform check has been simplified and moved to static constructor of `NativeMethods`.
* We should load x64/x86 version of library relative to assembly, not relative to executable. This matters when running tests etc and has been fixed.
* Replaced obsolete `curl_escape` to `curl_easy_escape`. This function was marked obsolete in 2006. Also, I fixed handling of string containing NULL characters.
